### PR TITLE
fix: resolve OpenAI import constructor bug in tests

### DIFF
--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -298,6 +298,6 @@ class AIService {
 // Singleton instance
 export const aiService = new AIService();
 
-// Export types and utilities
-export type { AIService };
+// Export the class and utilities
+export { AIService };
 export { createClient };


### PR DESCRIPTION
## Summary
- **Fixed OpenAI constructor breaking test suite** - Resolves `TypeError: _ai.default is not a constructor`
- Export AIService class properly for test instantiation
- Fix test mocking of OpenAI constructor and Supabase createClient
- Update test methods to use correct AIService API (callModel vs createCompletion)
- Update test assertions to match actual API parameters

## Technical Changes
- **src/lib/ai.ts**: Added proper `{ AIService }` export alongside singleton
- **tests/backend-comprehensive.test.ts**: 
  - Fixed mocking strategy for OpenAI and Supabase dependencies
  - Updated imports to use named exports instead of default imports
  - Fixed test method calls to match actual AIService API
  - Updated assertions to include all API parameters (max_tokens, temperature)

## Test Results
- ✅ **"should create completion successfully"** - PASSING
- ✅ **"should handle API errors gracefully"** - PASSING  
- Core OpenAI constructor issue completely resolved

## Impact
This fix unblocks the CI pipeline and restores backend comprehensive test execution.

Fixes #100