### PR TITLE
fix: implement singleton pattern for DatabaseService to prevent multiple Supabase client instances

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -88,13 +88,24 @@ export interface AgentLog {
 export class DatabaseService {
   private client = supabaseClient;
   private admin = supabaseAdmin;
+  private static instance: DatabaseService;
 
-  constructor() {
+  private constructor() {
+    this.client = supabaseClient;
+    this.admin = supabaseAdmin;
+
     if (!this.client || !this.admin) {
       console.warn(
         'Supabase clients not initialized. Check environment variables.'
       );
     }
+  }
+
+  static getInstance(): DatabaseService {
+    if (!DatabaseService.instance) {
+      DatabaseService.instance = new DatabaseService();
+    }
+    return DatabaseService.instance;
   }
 
   // Ideas CRUD operations
@@ -447,7 +458,7 @@ export class DatabaseService {
 }
 
 // Export singleton instance
-export const dbService = new DatabaseService();
+export const dbService = DatabaseService.getInstance();
 
 // Export types for external use
 export type { Database };

--- a/tests/backend-comprehensive.test.ts
+++ b/tests/backend-comprehensive.test.ts
@@ -19,6 +19,7 @@ import { createClient } from '@supabase/supabase-js';
 import OpenAI from 'openai';
 import { ExportService } from '@/lib/exports';
 import ClarifierAgent from '@/lib/agents/clarifier';
+import { DatabaseService } from '@/lib/db';
 import {
   mockEnvVars,
   createMockSupabaseClient,
@@ -165,7 +166,7 @@ describe('Backend Service Tests', () => {
           error: null,
         });
 
-      const dbService = new DatabaseService();
+      const dbService = DatabaseService.getInstance();
       const result = await dbService.createIdea('Test idea');
 
       expect(result).toEqual(mockIdea);
@@ -179,7 +180,7 @@ describe('Backend Service Tests', () => {
         error: mockError,
       });
 
-      const dbService = new DatabaseService();
+      const dbService = DatabaseService.getInstance();
 
       await expect(dbService.createIdea('Test idea')).rejects.toThrow(
         'Database error'
@@ -197,7 +198,7 @@ describe('Backend Service Tests', () => {
         error: null,
       });
 
-      const dbService = new DatabaseService();
+      const dbService = DatabaseService.getInstance();
       const result = await dbService.getIdea('test-id');
 
       expect(result).toEqual(mockIdea);
@@ -218,7 +219,7 @@ describe('Backend Service Tests', () => {
           error: null,
         });
 
-      const dbService = new DatabaseService();
+      const dbService = DatabaseService.getInstance();
       const result = await dbService.createClarificationSession('idea-id');
 
       expect(result).toEqual(mockSession);
@@ -232,7 +233,7 @@ describe('Backend Service Tests', () => {
 
       mockSupabase.from().insert().mockResolvedValue(mockAnswers);
 
-      const dbService = new DatabaseService();
+      const dbService = DatabaseService.getInstance();
       const result = await dbService.saveAnswers('session-id', {
         '1': 'answer1',
       });

--- a/tests/integration-comprehensive.test.tsx
+++ b/tests/integration-comprehensive.test.tsx
@@ -212,8 +212,7 @@ describe('Integration Tests - User Workflows', () => {
 
       global.fetch = createMockFetch(mockDbData);
 
-      const DatabaseService = require('@/lib/db').default;
-      const dbService = new DatabaseService();
+      const { dbService } = require('@/lib/db');
 
       // Test complete CRUD cycle
       const idea = await dbService.createIdea('Test idea');


### PR DESCRIPTION
## Summary
- Implemented singleton pattern for DatabaseService to prevent multiple Supabase client instances
- Fixed Multiple GoTrueClient instances warnings appearing in test console output
- Updated all test files to use DatabaseService.getInstance() instead of new DatabaseService()

## What's Fixed
- Added private constructor and getInstance() method to DatabaseService class
- Updated dbService export to use singleton instance
- Fixed all test files that were creating multiple DatabaseService instances
- Prevents undefined behavior in concurrent operations

## Testing
- Verified no Multiple GoTrueClient warnings in test output
- Confirmed build passes successfully
- All existing functionality preserved

## Issue
Resolves #102