### PR TITLE
Fix IdeaInput test to use fetch API mock instead of dbService mock

### DIFF
--- a/tests/IdeaInput.test.tsx
+++ b/tests/IdeaInput.test.tsx
@@ -1,15 +1,14 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import IdeaInput from '@/components/IdeaInput';
-import { dbService } from '@/lib/db';
 
-jest.mock('@/lib/db', () => ({
-  dbService: {
-    createIdea: jest.fn().mockResolvedValue({ id: 'test-idea-123' }),
-  },
-}));
+global.fetch = jest.fn();
 
 describe('IdeaInput', () => {
+  beforeEach(() => {
+    (global.fetch as jest.Mock).mockClear();
+  });
+
   it('renders textarea and submit button', () => {
     const mockOnSubmit = jest.fn();
     render(<IdeaInput onSubmit={mockOnSubmit} />);
@@ -27,6 +26,21 @@ describe('IdeaInput', () => {
     const textarea = screen.getByLabelText(/what's your idea/i);
     const submitButton = screen.getByRole('button', {
       name: /start clarifying/i,
+    });
+
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        success: true,
+        data: {
+          id: 'test-idea-123',
+          title: 'Test idea with more details',
+          status: 'draft',
+          createdAt: new Date().toISOString(),
+        },
+        requestId: 'test-req-123',
+        timestamp: new Date().toISOString(),
+      }),
     });
 
     fireEvent.change(textarea, {


### PR DESCRIPTION
## Summary
- Fixed failing IdeaInput.test.tsx test by updating mock to use fetch API instead of dbService
- Component was previously refactored to use /api/ideas endpoint instead of direct dbService calls
- Test mock was not updated to match the new component implementation

## Changes
- Updated tests/IdeaInput.test.tsx to mock global.fetch instead of dbService
- Added proper API response mock matching standardSuccessResponse format
- Fixed test expectations to work with new async fetch pattern

## Impact
- All 4 IdeaInput tests now passing (was 1 failure before)
- No changes to production code
- Build, lint, and type-check all passing

## Testing
```bash
npm test -- tests/IdeaInput.test.tsx
# 4 tests passing, 0 failures
```