### PR TITLE
fix: Add validation for question count in ClarifierAgent generateQuestions (fixes #118)

### DIFF
--- a/src/lib/agents/clarifier-engine/QuestionGenerator.ts
+++ b/src/lib/agents/clarifier-engine/QuestionGenerator.ts
@@ -65,13 +65,22 @@ export class QuestionGenerator {
           isArrayOf(data, isClarifierQuestion)
       );
 
-      return questionsData.map((q, index: number) => ({
+      const mappedQuestions = questionsData.map((q, index: number) => ({
         id: q.id || `q_${index + 1}`,
         question: q.question || `Question ${index + 1}`,
         type: q.type || 'open',
         options: q.options || [],
         required: q.required !== false,
       })) as ClarifierQuestion[];
+
+      if (mappedQuestions.length < 3 || mappedQuestions.length > 5) {
+        logger.warn(
+          `Invalid question count: ${mappedQuestions.length}, using fallback`
+        );
+        return this.getFallbackQuestions();
+      }
+
+      return mappedQuestions;
     } catch (error) {
       logger.error('Failed to generate questions', error);
 


### PR DESCRIPTION
## Summary

Fixes #118: ClarifierAgent generateQuestions validation logic

## Problem

The `generateQuestions` method in ClarifierAgent did not properly validate AI responses after parsing. When AI service returned:
- Valid JSON
- But incomplete data (e.g., only 1 question instead of 3-5)

The code would map the incomplete questions without validation and return them, rather than falling back to the default 3 questions.

The fallback mechanism only triggered on:
- JSON parse errors
- Network/AI service errors

It did NOT trigger on:
- Valid JSON with invalid structure
- Missing required fields
- Insufficient number of questions (less than 3)
- Too many questions (more than 5)

## Solution

Added validation logic after mapping questions from AI response:

1. **Store mapped questions in variable** (before this commit they were returned directly)
2. **Validate question count**: Check if array has 3-5 questions
3. **Use fallback questions** if count is invalid
4. **Log warning** when using fallback

## Changes

**File:** `src/lib/agents/clarifier-engine/QuestionGenerator.ts`

- Lines 68-82: Added question count validation
- Added warning log for invalid question counts
- Ensures fallback questions are used when AI returns invalid counts

## Testing

- ✅ TypeScript compilation passes
- ✅ Build succeeds
- ✅ Validation logic properly triggers fallback on invalid counts

## Impact

- **Fixes**: Test failures related to insufficient questions
- **Improves**: Robustness of ClarifierAgent
- **Maintains**: Existing fallback behavior for service errors

---

**Fixes:** #118
**Agent:** Autonomous Agent
**Date:** 2026-01-20