### PR TITLE
🎨 Palette: Add "Copy to Clipboard" button to BlueprintDisplay

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -4,3 +4,8 @@
 **Learning:** For Next.js applications, always use the `Link` component for internal navigation to ensure a smooth SPA experience. When implementing custom navigation elements (like logos or icons), consistent focus-visible rings are crucial for keyboard accessibility. On mobile, preventing body scroll when a menu is open is a key micro-UX touch that prevents disorientation.
 
 **Action:** Use `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 rounded-md` for interactive elements and implement body scroll lock for all modal-like overlays.
+
+## 2026-02-04 - [Global Toast Feedback]
+**Learning:** The `ToastContainer` component exposes a global `window.showToast` function. This is extremely useful for providing immediate feedback (like "Copied to clipboard") from utility functions or deep components without passing down state. However, it requires careful TypeScript casting to avoid `any` or linting errors.
+
+**Action:** When using `window.showToast`, cast window as `Window & { showToast?: (options: ToastOptions) => void }` and always check for existence before calling.

--- a/src/components/BlueprintDisplay.tsx
+++ b/src/components/BlueprintDisplay.tsx
@@ -6,6 +6,7 @@ import Button from '@/components/Button';
 import Skeleton from '@/components/Skeleton';
 import LoadingAnnouncer from '@/components/LoadingAnnouncer';
 import { generateBlueprintTemplate } from '@/templates/blueprint-template';
+import { ToastOptions } from '@/components/ToastContainer';
 
 interface BlueprintDisplayProps {
   idea: string;
@@ -43,6 +44,24 @@ const BlueprintDisplayComponent = function BlueprintDisplay({
     a.click();
     document.body.removeChild(a);
     URL.revokeObjectURL(url);
+  };
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(blueprint);
+      const win = window as unknown as Window & {
+        showToast?: (options: ToastOptions) => void;
+      };
+      if (typeof window !== 'undefined' && win.showToast) {
+        win.showToast({
+          type: 'success',
+          message: 'Blueprint copied to clipboard!',
+          duration: 3000,
+        });
+      }
+    } catch (err) {
+      console.error('Failed to copy blueprint:', err);
+    }
   };
 
   if (isGenerating) {
@@ -122,14 +141,24 @@ const BlueprintDisplayComponent = function BlueprintDisplay({
             >
               Your Project Blueprint
             </h2>
-            <Button
-              onClick={handleDownload}
-              variant="primary"
-              fullWidth={false}
-              aria-label="Download blueprint as Markdown file"
-            >
-              Download Markdown
-            </Button>
+            <div className="flex flex-col sm:flex-row gap-2 w-full sm:w-auto">
+              <Button
+                onClick={handleCopy}
+                variant="outline"
+                fullWidth={false}
+                aria-label="Copy blueprint to clipboard"
+              >
+                Copy to Clipboard
+              </Button>
+              <Button
+                onClick={handleDownload}
+                variant="primary"
+                fullWidth={false}
+                aria-label="Download blueprint as Markdown file"
+              >
+                Download Markdown
+              </Button>
+            </div>
           </div>
         </header>
 

--- a/tests/BlueprintDisplay.test.tsx
+++ b/tests/BlueprintDisplay.test.tsx
@@ -86,4 +86,45 @@ describe('BlueprintDisplay', () => {
     expect(downloadButton).toBeInTheDocument();
     expect(downloadButton.closest('button')).toBeEnabled();
   });
+
+  it('has copy button after loading and handles copying', async () => {
+    const idea = 'Test idea';
+    const answers = { target_audience: 'Developers' };
+
+    // Mock clipboard
+    const mockWriteText = jest.fn().mockImplementation(() => Promise.resolve());
+    Object.defineProperty(navigator, 'clipboard', {
+      value: {
+        writeText: mockWriteText,
+      },
+      writable: true,
+      configurable: true,
+    });
+
+    // Mock showToast
+    const mockShowToast = jest.fn();
+    (window as any).showToast = mockShowToast;
+
+    render(<BlueprintDisplay idea={idea} answers={answers} />);
+
+    await waitFor(
+      () => {
+        expect(screen.getByText(/copy to clipboard/i)).toBeInTheDocument();
+      },
+      { timeout: 3000 }
+    );
+
+    const copyButton = screen.getByText(/copy to clipboard/i);
+    copyButton.click();
+
+    await waitFor(() => {
+      expect(mockWriteText).toHaveBeenCalled();
+      expect(mockShowToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'success',
+          message: 'Blueprint copied to clipboard!',
+        })
+      );
+    });
+  });
 });


### PR DESCRIPTION
This PR adds a small but impactful micro-UX improvement to the project blueprint results page. Users can now quickly copy the entire generated blueprint to their clipboard with a single click, making it much easier to paste the plan into other tools like Notion, Trello, or Slack.

What:
- A new "Copy to Clipboard" button (outline variant) in the header of the BlueprintDisplay component.
- A success toast notification appears after a successful copy.

Why:
- Reduces friction for users who want to move their plans to other productivity tools without downloading and opening a Markdown file.

Accessibility:
- Added `aria-label="Copy blueprint to clipboard"` to the new button.
- Maintained consistent focus states.
- Follows existing design patterns.

---
*PR created automatically by Jules for task [7712724559449792222](https://jules.google.com/task/7712724559449792222) started by @cpa03*