### PR TITLE
🛡️ Sentinel: Fix PII leak in error responses

### DIFF
--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,4 +1,4 @@
-import { redactPII } from './pii-redaction';
+import { redactPII, redactPIIInObject } from './pii-redaction';
 
 export interface ErrorDetail {
   field?: string;
@@ -47,9 +47,11 @@ export class AppError extends Error {
 
   toJSON(): ErrorResponse {
     return {
-      error: this.message,
+      error: redactPII(this.message),
       code: this.code,
-      details: this.details,
+      details: this.details
+        ? (redactPIIInObject(this.details) as ErrorDetail[])
+        : undefined,
       timestamp: new Date().toISOString(),
       retryable: this.retryable,
       suggestions: this.suggestions,
@@ -103,13 +105,13 @@ export class RateLimitError extends AppError {
 
   toJSON(): ErrorResponse {
     return {
-      error: this.message,
+      error: redactPII(this.message),
       code: this.code,
-      details: [
+      details: redactPIIInObject([
         {
           message: `Limit: ${this.limit}, Remaining: ${this.remaining}`,
         },
-      ],
+      ]) as ErrorDetail[],
       timestamp: new Date().toISOString(),
       retryable: true,
       suggestions: this.suggestions,
@@ -186,7 +188,7 @@ export class CircuitBreakerError extends AppError {
 
   toJSON(): ErrorResponse {
     return {
-      error: this.message,
+      error: redactPII(this.message),
       code: this.code,
       timestamp: new Date().toISOString(),
       retryable: true,

--- a/tests/errors.test.ts
+++ b/tests/errors.test.ts
@@ -93,6 +93,50 @@ describe('AppError', () => {
       );
     });
 
+    it('should redact PII in message', () => {
+      const error = new AppError(
+        'User with email test@example.com already exists',
+        ErrorCode.CONFLICT
+      );
+      const json = error.toJSON();
+
+      expect(json.error).not.toContain('test@example.com');
+      expect(json.error).toContain('[REDACTED_EMAIL]');
+    });
+
+    it('should redact PII in details', () => {
+      const details: ErrorDetail[] = [
+        {
+          field: 'email',
+          message: 'User with email test@example.com already exists',
+        },
+      ];
+      const error = new AppError(
+        'Validation failed',
+        ErrorCode.VALIDATION_ERROR,
+        400,
+        details
+      );
+      const json = error.toJSON();
+
+      expect(json.details![0].message).not.toContain('test@example.com');
+      expect(json.details![0].message).toContain('[REDACTED_EMAIL]');
+    });
+
+    it('should redact PII in ValidationError (subclass)', () => {
+      const details: ErrorDetail[] = [
+        {
+          field: 'email',
+          message: 'Email test@example.com is invalid',
+        },
+      ];
+      const error = new ValidationError(details);
+      const json = error.toJSON();
+
+      expect(json.details![0].message).not.toContain('test@example.com');
+      expect(json.details![0].message).toContain('[REDACTED_EMAIL]');
+    });
+
     it('should handle undefined details', () => {
       const error = new AppError('Test error', ErrorCode.INTERNAL_ERROR);
       const json = error.toJSON();


### PR DESCRIPTION
Identified a security vulnerability where personally identifiable information (PII) like email addresses could be leaked in API error responses if they were included in the error message or details.

Fixed this by centralizing PII redaction in the `AppError.toJSON` method, which is used by `toErrorResponse` to serialize errors for the client. Also ensured that subclasses overriding `toJSON` follow the same pattern.

Added tests to `tests/errors.test.ts` to verify redaction for both the base `AppError` and its subclasses (like `ValidationError`).

---
*PR created automatically by Jules for task [1986479091895522814](https://jules.google.com/task/1986479091895522814) started by @cpa03*