### PR TITLE
🎨 Palette: Enhanced Copy to Clipboard feedback

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,7 @@
+## 2025-05-15 - Clipboard verification in Playwright
+**Learning:** Playwright E2E tests involving clipboard actions (e.g., `navigator.clipboard.writeText`) require explicitly granting `clipboard-read` and `clipboard-write` permissions in the browser context to succeed in headless environments.
+**Action:** Use `browser.new_context(permissions=["clipboard-read", "clipboard-write"])` in verification scripts involving copy-to-clipboard features.
+
+## 2025-05-15 - Multi-modal Copy Feedback
+**Learning:** Providing immediate local visual feedback (e.g., changing button text to "Copied!") in addition to a global toast notification significantly improves the perceived responsiveness of clipboard actions, as it confirms exactly which element was acted upon.
+**Action:** Always implement local state changes for copy buttons to provide clear, localized confirmation.

--- a/src/components/BlueprintDisplay.tsx
+++ b/src/components/BlueprintDisplay.tsx
@@ -23,6 +23,7 @@ const BlueprintDisplayComponent = function BlueprintDisplay({
 }: BlueprintDisplayProps) {
   const [isGenerating, setIsGenerating] = useState(true);
   const [blueprint, setBlueprint] = useState('');
+  const [copied, setCopied] = useState(false);
 
   // Simulate blueprint generation
   useEffect(() => {
@@ -64,6 +65,9 @@ const BlueprintDisplayComponent = function BlueprintDisplay({
 
     try {
       await navigator.clipboard.writeText(blueprint);
+      setCopied(true);
+      setTimeout(() => setCopied(false), UI_CONFIG.COPY_FEEDBACK_DURATION);
+
       if (typeof window !== 'undefined' && win.showToast) {
         win.showToast({
           type: 'success',
@@ -168,7 +172,7 @@ const BlueprintDisplayComponent = function BlueprintDisplay({
                 fullWidth={false}
                 aria-label="Copy blueprint to clipboard"
               >
-                Copy to Clipboard
+                {copied ? 'Copied!' : 'Copy to Clipboard'}
               </Button>
               <Button
                 onClick={handleDownload}


### PR DESCRIPTION
This PR implements a micro-UX improvement for the project blueprint results. When a user clicks the "Copy to Clipboard" button, the button text now immediately changes to "Copied!" for 2 seconds. This provides clear, localized feedback that the action was successful, complementing the existing global toast notification.

Accessibility:
- The button text change provides immediate visual confirmation for all users.
- Existing ARIA labels and toast notifications remain for screen reader users.

Verification:
- Verified via Playwright script with mocked API responses and clipboard permissions.
- Screenshot confirms the "Copied!" state.
- All existing tests pass.
- Build and lint pass.

---
*PR created automatically by Jules for task [13228673590640918591](https://jules.google.com/task/13228673590640918591) started by @cpa03*