### PR TITLE
🛡️ Sentinel: Fix stack trace leakage in PII redaction

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-15 - Stack Trace Leakage in PII Redaction
+**Vulnerability:** The `redactPIIInObject` function in `src/lib/pii-redaction.ts` explicitly included the `stack` property when redacting `Error` objects. This information was then serialized and potentially sent to clients in API error responses (via `AppError.toJSON`).
+**Learning:** While the tool was designed to redact PII (emails, keys, etc.) from objects, it inadvertently introduced a different security risk by including internal application structure (file paths, function names) which are contained in stack traces. The implementation prioritized debugging convenience over security by default.
+**Prevention:** Always exclude sensitive internal metadata like stack traces from data structures that are intended for client-side consumption or general logging. If stack traces are needed for internal debugging, they should be handled via a separate, secure channel or restricted to non-production environments.


### PR DESCRIPTION
Identified and fixed a security vulnerability where internal stack traces were being leaked during PII redaction of Error objects. Modified `src/lib/pii-redaction.ts` to ensure the `stack` property is never included in the redacted output, while preserving `name` and `message`. This change improves the security posture of the API by preventing the exposure of internal application details to clients. Verified the fix with reproduction tests and ensured no regressions with existing tests.

---
*PR created automatically by Jules for task [405647251680745673](https://jules.google.com/task/405647251680745673) started by @cpa03*