### PR TITLE
🛡️ Sentinel: Improve PII redaction robustness

### DIFF
--- a/src/lib/config/constants.ts
+++ b/src/lib/config/constants.ts
@@ -557,7 +557,7 @@ export const PII_REDACTION_CONFIG = {
    * API key prefixes for regex patterns
    */
   API_KEY_PREFIXES: [
-    'api[_-]?key',
+    'api[-_ ]?key',
     'apikey',
     'secret',
     'token',
@@ -569,7 +569,7 @@ export const PII_REDACTION_CONFIG = {
     'password',
     'passphrase',
     'bearer',
-    'access[_-]?key',
+    'access[-_ ]?key',
   ] as const,
 
   /**

--- a/src/lib/pii-redaction.ts
+++ b/src/lib/pii-redaction.ts
@@ -86,7 +86,7 @@ const PII_REGEX_PATTERNS: PIIPatterns = {
   creditCard: /\b(?:\d{4}[-\s]?){3}\d{4}\b/g,
   ipAddress: /\b(?:[0-9]{1,3}\.){3}[0-9]{1,3}\b/g,
   apiKey:
-    /(?:api[_-]?key|apikey|secret|token|password|passphrase|credential|auth|authorization|access[_-]?key|bearer|admin[-_ ]?key|adminkey)[\s:=]+['"]?([a-zA-Z0-9_-]{20,})['"]?|(?:sk|pk|rk)_(?:live|test)_[a-zA-Z0-9]{24,64}|sk-[a-zA-Z0-9_-]{32,64}|AKIA[0-9A-Z]{16}/gi,
+    /(?:api[-_ ]?key|apikey|secret|token|password|passphrase|credential|auth|authorization|access[-_ ]?key|bearer|admin[-_ ]?key|adminkey)[\s:=]+['"]?([a-zA-Z0-9_-]{4,})['"]?|(?:sk|pk|rk)_(?:live|test)_[a-zA-Z0-9]{24,64}|sk-[a-zA-Z0-9_-]{32,64}|AKIA[0-9A-Z]{16}/gi,
   jwt: /eyJ[a-zA-Z0-9_-]*\.eyJ[a-zA-Z0-9_-]*\.[a-zA-Z0-9_-]*/g,
   urlWithCredentials: /[a-zA-Z]+:\/\/[^:\s]+:[^@\s]+@[^\s]+/g,
   // US Passport: 9 characters (alphanumeric, starting with letter for newer formats)
@@ -161,7 +161,7 @@ export function redactPII(text: string): string {
  * Combined regex for sensitive field detection to avoid iterating through an array
  */
 const SENSITIVE_FIELD_REGEX =
-  /api[_-]?key|apikey|secret|token|password|passphrase|credential|auth|authorization|access[_-]?key|bearer|session[_-]?id|cookie|set-cookie|xsrf-token|csrf-token|private[_-]?key|secret[_-]?key|connection[_-]?string|email|phone|ssn|credit[_-]?card|ip[_-]?address|admin[-_ ]?key|adminkey/i;
+  /api[-_ ]?key|apikey|secret|token|password|passphrase|credential|auth|authorization|access[-_ ]?key|bearer|session[_-]?id|cookie|set-cookie|xsrf-token|csrf-token|private[_-]?key|secret[_-]?key|connection[_-]?string|email|phone|ssn|credit[_-]?card|ip[_-]?address|admin[-_ ]?key|adminkey/i;
 
 const SAFE_FIELDS_SET = new Set<string>(
   PII_REDACTION_CONFIG.SAFE_FIELDS.map((f) => f.toLowerCase())

--- a/tests/pii-redaction.test.ts
+++ b/tests/pii-redaction.test.ts
@@ -759,4 +759,39 @@ describe('PII Redaction Utility', () => {
       expect(statsAfter.labelCacheSize).toBe(0);
     });
   });
+
+  describe('Improved Secret Redaction', () => {
+    it('should redact short passwords and secrets (>= 4 chars)', () => {
+      const inputs = [
+        'password: 1234',
+        'password=123456',
+        'secret: abcd',
+        'token: xyz1',
+      ];
+
+      inputs.forEach((input) => {
+        const output = redactPII(input);
+        expect(output).toContain('[REDACTED_API_KEY]');
+      });
+    });
+
+    it('should redact API keys with spaces in prefixes', () => {
+      const inputs = [
+        'API key: 12345678901234567890',
+        'access key: 12345678901234567890',
+        'admin key: 12345678901234567890',
+      ];
+
+      inputs.forEach((input) => {
+        const output = redactPII(input);
+        expect(output).toContain('[REDACTED_API_KEY]');
+      });
+    });
+
+    it('should not redact extremely short values (< 4 chars)', () => {
+      const input = 'password: 123';
+      const output = redactPII(input);
+      expect(output).toBe(input);
+    });
+  });
 });


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: PII Leak in logs. Short secrets (under 20 characters) and prefixes with spaces were not being redacted.
🎯 Impact: Sensitive user data like short passwords or tokens could be exposed in application logs or error messages.
🔧 Fix: Updated PII redaction regex to support shorter values (>= 4 chars) and flexible prefix separators (including spaces).
✅ Verification: Added and verified new test cases in `tests/pii-redaction.test.ts`. Full test suite and linter pass.

---
*PR created automatically by Jules for task [10296864734529420565](https://jules.google.com/task/10296864734529420565) started by @cpa03*