### PR TITLE
🎨 Palette: Standardize overlay backdrops with blur

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -12,3 +12,7 @@
 ## 2026-02-25 - [Tooltip for Icon-Only Clear Button]
 **Learning:** Adding a tooltip to icon-only buttons (like a "Clear" button in an input field) provides essential context for users before they interact with it. To prevent the `Tooltip` component's `relative inline-flex` styles from disrupting the `absolute` positioning of elements within an input container, the `Tooltip` should be wrapped in an `absolute` positioned `div` that mirrors the original element's placement.
 **Action:** Always wrap `Tooltip` in an `absolute` positioned container when used for elements that require precise absolute placement within a parent.
+
+## 2026-03-04 - [Standardizing Overlay Backdrops with Blur]
+**Learning:** Using a consistent `backdrop-blur-sm` with `bg-black/50` across all overlays (modals, mobile nav, onboarding) provides a more cohesive and premium feel. It helps the foreground content stand out by subtly obscuring background distractions without losing context entirely.
+**Action:** Always apply `backdrop-blur-sm` and standardize background opacity to `bg-black/50` for all full-screen or significant overlays to ensure visual consistency with the `LoadingOverlay` component.

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -458,7 +458,7 @@ export default function DashboardPage() {
       {deleteModal.isOpen && deleteModal.idea && (
         <div
           ref={modalRef}
-          className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50"
+          className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center p-4 z-50"
           role="dialog"
           aria-modal="true"
           aria-labelledby="delete-modal-title"

--- a/src/components/KeyboardShortcutsHelp.tsx
+++ b/src/components/KeyboardShortcutsHelp.tsx
@@ -387,7 +387,7 @@ function KeyboardShortcutsHelpComponent({
       aria-labelledby="keyboard-shortcuts-title"
     >
       <div
-        className={`absolute inset-0 bg-black transition-opacity duration-300 ${isLeaving ? 'opacity-0' : 'opacity-50'}`}
+        className={`absolute inset-0 bg-black/50 backdrop-blur-sm transition-opacity duration-300 ${isLeaving ? 'opacity-0' : 'opacity-100'}`}
         aria-hidden="true"
       />
       <div

--- a/src/components/MobileNav.tsx
+++ b/src/components/MobileNav.tsx
@@ -193,7 +193,7 @@ function MobileNavComponent() {
         <>
           {/* Backdrop overlay */}
           <div
-            className="fixed inset-0 top-16 bg-black bg-opacity-50 z-[99] fade-in"
+            className="fixed inset-0 top-16 bg-black/50 backdrop-blur-sm z-[99] fade-in"
             onClick={closeMenu}
             onTouchEnd={closeMenu}
             aria-hidden="true"

--- a/src/components/UserOnboarding.tsx
+++ b/src/components/UserOnboarding.tsx
@@ -223,7 +223,7 @@ export default function UserOnboarding() {
     <>
       {/* Backdrop overlay */}
       <div
-        className="fixed inset-0 bg-black/40 z-40 transition-opacity duration-300"
+        className="fixed inset-0 bg-black/50 backdrop-blur-sm z-40 transition-opacity duration-300"
         aria-hidden="true"
         onClick={handleSkip}
       />


### PR DESCRIPTION
Implemented a consistent micro-UX enhancement across all major application overlays. Added `backdrop-blur-sm` and standardized background opacity to `bg-black/50` for MobileNav, KeyboardShortcutsHelp, UserOnboarding, and Dashboard delete modal. This improves visual polish and focus by subtly obscuring background context while overlays are active. The change was verified with Playwright screenshots and existing tests.

---
*PR created automatically by Jules for task [12333008589761750008](https://jules.google.com/task/12333008589761750008) started by @cpa03*