### PR TITLE
🛡️ Sentinel: [HIGH] Fix CSRF broad suffix matching vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-03-05 - CSRF Broad Suffix Matching Vulnerability
+**Vulnerability:** The CSRF protection logic in `src/lib/security/csrf.ts` allowed any origin ending in `.vercel.app` or `.pages.dev` to be considered "trusted".
+**Learning:** Broad suffix matching on shared hosting platforms (like Vercel or Cloudflare Pages) allows any user on those platforms to bypass CSRF protections. This is a form of "Same-Platform Attack".
+**Prevention:** Always use exact origin matching for trusted domains. Avoid `endsWith()` or similar suffix checks for domains you do not fully control the entire subdomain space of.

--- a/src/lib/security/csrf.ts
+++ b/src/lib/security/csrf.ts
@@ -78,19 +78,6 @@ function isTrustedOrigin(origin: string, trustedOrigins: string[]): boolean {
       return true;
     }
 
-    if (
-      normalizedTrusted.includes('.vercel.app') &&
-      normalizedOrigin.endsWith('.vercel.app')
-    ) {
-      return true;
-    }
-
-    if (
-      normalizedTrusted.includes('.pages.dev') &&
-      normalizedOrigin.endsWith('.pages.dev')
-    ) {
-      return true;
-    }
   }
 
   return false;

--- a/tests/security/csrf.test.ts
+++ b/tests/security/csrf.test.ts
@@ -1,0 +1,68 @@
+import { validateCSRF, CSRF_CONFIG } from '@/lib/security/csrf';
+
+describe('CSRF Validation', () => {
+  const trustedOrigins = ['https://ideaflow.vercel.app', 'https://ideaflow.pages.dev'];
+
+  beforeAll(() => {
+    // @ts-ignore
+    CSRF_CONFIG.ENABLED = true;
+  });
+
+  afterAll(() => {
+    // @ts-ignore
+    CSRF_CONFIG.ENABLED = process.env.NODE_ENV !== 'test';
+  });
+
+  it('should accept exact matches', () => {
+    const request = new Request('https://ideaflow.vercel.app/api/ideas', {
+      method: 'POST',
+      headers: { 'Origin': 'https://ideaflow.vercel.app' }
+    });
+    const result = validateCSRF(request, { trustedOrigins });
+    expect(result.valid).toBe(true);
+  });
+
+  it('should reject malicious subdomains', () => {
+    const request = new Request('https://ideaflow.vercel.app/api/ideas', {
+      method: 'POST',
+      headers: { 'Origin': 'https://attacker-app.vercel.app' }
+    });
+    const result = validateCSRF(request, { trustedOrigins });
+    expect(result.valid).toBe(false);
+  });
+
+  it('should reject malicious pages.dev subdomains', () => {
+    const request = new Request('https://ideaflow.vercel.app/api/ideas', {
+      method: 'POST',
+      headers: { 'Origin': 'https://attacker.pages.dev' }
+    });
+    const result = validateCSRF(request, { trustedOrigins });
+    expect(result.valid).toBe(false);
+  });
+
+  it('should handle trailing slashes in origin', () => {
+    const request = new Request('https://ideaflow.vercel.app/api/ideas', {
+      method: 'POST',
+      headers: { 'Origin': 'https://ideaflow.vercel.app/' }
+    });
+    const result = validateCSRF(request, { trustedOrigins });
+    expect(result.valid).toBe(true);
+  });
+
+  it('should handle uppercase origins', () => {
+    const request = new Request('https://ideaflow.vercel.app/api/ideas', {
+      method: 'POST',
+      headers: { 'Origin': 'HTTPS://IDEAFLOW.VERCEL.APP' }
+    });
+    const result = validateCSRF(request, { trustedOrigins });
+    expect(result.valid).toBe(true);
+  });
+
+  it('should accept when no origin/referer but method is state-changing (fail-open for non-browser)', () => {
+    const request = new Request('https://ideaflow.vercel.app/api/ideas', {
+      method: 'POST'
+    });
+    const result = validateCSRF(request, { trustedOrigins });
+    expect(result.valid).toBe(true);
+  });
+});


### PR DESCRIPTION
Identified and fixed a high-severity CSRF vulnerability in `src/lib/security/csrf.ts`. The original logic used broad suffix matching for `.vercel.app` and `.pages.dev` domains, which are shared hosting platforms. This allowed any site hosted on these platforms to bypass the CSRF protection.

The fix involves removing the suffix matching and enforcing exact origin comparison.

Verified the fix using a standalone reproduction script that confirmed malicious subdomains are now blocked while legitimate origins remain trusted.

Updated `.jules/sentinel.md` with the learning.

---
*PR created automatically by Jules for task [5934172994751834403](https://jules.google.com/task/5934172994751834403) started by @cpa03*