### PR TITLE
🎨 Palette: Add backdrop blur polish to overlays

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -458,7 +458,7 @@ export default function DashboardPage() {
       {deleteModal.isOpen && deleteModal.idea && (
         <div
           ref={modalRef}
-          className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center p-4 z-50"
+          className="fixed inset-0 bg-black bg-opacity-50 backdrop-blur-sm flex items-center justify-center p-4 z-50"
           role="dialog"
           aria-modal="true"
           aria-labelledby="delete-modal-title"

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -458,7 +458,7 @@ export default function DashboardPage() {
       {deleteModal.isOpen && deleteModal.idea && (
         <div
           ref={modalRef}
-          className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50"
+          className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center p-4 z-50"
           role="dialog"
           aria-modal="true"
           aria-labelledby="delete-modal-title"

--- a/src/components/KeyboardShortcutsHelp.tsx
+++ b/src/components/KeyboardShortcutsHelp.tsx
@@ -387,7 +387,7 @@ function KeyboardShortcutsHelpComponent({
       aria-labelledby="keyboard-shortcuts-title"
     >
       <div
-        className={`absolute inset-0 bg-black transition-opacity duration-300 ${isLeaving ? 'opacity-0' : 'opacity-50'}`}
+        className={`absolute inset-0 bg-black backdrop-blur-sm transition-opacity duration-300 ${isLeaving ? 'opacity-0' : 'opacity-50'}`}
         aria-hidden="true"
       />
       <div

--- a/src/components/MobileNav.tsx
+++ b/src/components/MobileNav.tsx
@@ -193,7 +193,7 @@ function MobileNavComponent() {
         <>
           {/* Backdrop overlay */}
           <div
-            className="fixed inset-0 top-16 bg-black/50 backdrop-blur-sm z-[99] fade-in"
+            className="fixed inset-0 top-16 bg-black bg-opacity-50 backdrop-blur-sm z-[99] fade-in"
             onClick={closeMenu}
             onTouchEnd={closeMenu}
             aria-hidden="true"

--- a/src/components/MobileNav.tsx
+++ b/src/components/MobileNav.tsx
@@ -193,7 +193,7 @@ function MobileNavComponent() {
         <>
           {/* Backdrop overlay */}
           <div
-            className="fixed inset-0 top-16 bg-black bg-opacity-50 z-[99] fade-in"
+            className="fixed inset-0 top-16 bg-black/50 backdrop-blur-sm z-[99] fade-in"
             onClick={closeMenu}
             onTouchEnd={closeMenu}
             aria-hidden="true"

--- a/src/components/UserOnboarding.tsx
+++ b/src/components/UserOnboarding.tsx
@@ -223,7 +223,7 @@ export default function UserOnboarding() {
     <>
       {/* Backdrop overlay */}
       <div
-        className="fixed inset-0 bg-black/40 z-40 transition-opacity duration-300"
+        className="fixed inset-0 bg-black/40 backdrop-blur-sm z-40 transition-opacity duration-300"
         aria-hidden="true"
         onClick={handleSkip}
       />

--- a/src/components/UserOnboarding.tsx
+++ b/src/components/UserOnboarding.tsx
@@ -223,7 +223,7 @@ export default function UserOnboarding() {
     <>
       {/* Backdrop overlay */}
       <div
-        className="fixed inset-0 bg-black/40 backdrop-blur-sm z-40 transition-opacity duration-300"
+        className="fixed inset-0 bg-black bg-opacity-40 backdrop-blur-sm z-40 transition-opacity duration-300"
         aria-hidden="true"
         onClick={handleSkip}
       />


### PR DESCRIPTION
### 💡 What: The UX enhancement added
Added `backdrop-blur-sm` to common overlay backdrops throughout the application.

### 🎯 Why: The user problem it solves
Backdrops were previously flat black/semi-transparent. Adding a subtle blur effect ("glassmorphism") provides better visual hierarchy, makes the interface feel more modern and polished, and helps users focus on the active modal or menu by softly obscuring the content behind it.

### 📸 Before/After: Screenshots if visual change
The backdrops now have a soft blur effect instead of just being semi-transparent black.

### ♿ Accessibility: Any a11y improvements made
Improved visual focus on active interactive elements (modals/menus) by increasing the visual separation from the background content. Verified that focus management and keyboard accessibility remain intact.

---
*PR created automatically by Jules for task [18343971514775373080](https://jules.google.com/task/18343971514775373080) started by @cpa03*