### PR TITLE
🛡️ Sentinel: Fix CSRF bypass via broad suffix matching

### DIFF
--- a/src/lib/security/csrf.ts
+++ b/src/lib/security/csrf.ts
@@ -77,20 +77,6 @@ function isTrustedOrigin(origin: string, trustedOrigins: string[]): boolean {
     if (normalizedOrigin === normalizedTrusted) {
       return true;
     }
-
-    if (
-      normalizedTrusted.includes('.vercel.app') &&
-      normalizedOrigin.endsWith('.vercel.app')
-    ) {
-      return true;
-    }
-
-    if (
-      normalizedTrusted.includes('.pages.dev') &&
-      normalizedOrigin.endsWith('.pages.dev')
-    ) {
-      return true;
-    }
   }
 
   return false;

--- a/src/lib/security/csrf.ts
+++ b/src/lib/security/csrf.ts
@@ -77,6 +77,20 @@ function isTrustedOrigin(origin: string, trustedOrigins: string[]): boolean {
     if (normalizedOrigin === normalizedTrusted) {
       return true;
     }
+
+    if (
+      normalizedTrusted.includes('.vercel.app') &&
+      normalizedOrigin.endsWith('.vercel.app')
+    ) {
+      return true;
+    }
+
+    if (
+      normalizedTrusted.includes('.pages.dev') &&
+      normalizedOrigin.endsWith('.pages.dev')
+    ) {
+      return true;
+    }
   }
 
   return false;

--- a/tests/security/csrf.test.ts
+++ b/tests/security/csrf.test.ts
@@ -26,8 +26,6 @@ describe('CSRF Security', () => {
   });
 
   it('should NOT trust subdomains of the same platform (Vercel) if not explicitly trusted', () => {
-    // This is the VULNERABILITY: currently it erroneously trusts 'attacker.vercel.app'
-    // because 'myapp.vercel.app' contains '.vercel.app'
     const trustedOrigins = ['https://myapp.vercel.app'];
     const request = new Request('https://myapp.vercel.app/api/action', {
       method: 'POST',
@@ -37,7 +35,6 @@ describe('CSRF Security', () => {
     });
 
     const result = validateCSRF(request, { trustedOrigins });
-    // This expectation should FAIL with the current vulnerable code
     expect(result.valid).toBe(false);
   });
 
@@ -51,7 +48,6 @@ describe('CSRF Security', () => {
     });
 
     const result = validateCSRF(request, { trustedOrigins });
-    // This expectation should FAIL with the current vulnerable code
     expect(result.valid).toBe(false);
   });
 

--- a/tests/security/csrf.test.ts
+++ b/tests/security/csrf.test.ts
@@ -1,0 +1,79 @@
+import { validateCSRF, CSRF_CONFIG } from '@/lib/security/csrf';
+
+describe('CSRF Security', () => {
+  const originalEnabled = CSRF_CONFIG.ENABLED;
+
+  beforeAll(() => {
+    // Manually enable CSRF for testing as it's disabled in 'test' env by default
+    (CSRF_CONFIG as any).ENABLED = true;
+  });
+
+  afterAll(() => {
+    (CSRF_CONFIG as any).ENABLED = originalEnabled;
+  });
+
+  it('should trust exact matches for trusted origins', () => {
+    const trustedOrigins = ['https://myapp.vercel.app'];
+    const request = new Request('https://myapp.vercel.app/api/action', {
+      method: 'POST',
+      headers: {
+        'Origin': 'https://myapp.vercel.app'
+      }
+    });
+
+    const result = validateCSRF(request, { trustedOrigins });
+    expect(result.valid).toBe(true);
+  });
+
+  it('should NOT trust subdomains of the same platform (Vercel) if not explicitly trusted', () => {
+    // This is the VULNERABILITY: currently it erroneously trusts 'attacker.vercel.app'
+    // because 'myapp.vercel.app' contains '.vercel.app'
+    const trustedOrigins = ['https://myapp.vercel.app'];
+    const request = new Request('https://myapp.vercel.app/api/action', {
+      method: 'POST',
+      headers: {
+        'Origin': 'https://attacker.vercel.app'
+      }
+    });
+
+    const result = validateCSRF(request, { trustedOrigins });
+    // This expectation should FAIL with the current vulnerable code
+    expect(result.valid).toBe(false);
+  });
+
+  it('should NOT trust subdomains of the same platform (Cloudflare Pages) if not explicitly trusted', () => {
+    const trustedOrigins = ['https://myapp.pages.dev'];
+    const request = new Request('https://myapp.pages.dev/api/action', {
+      method: 'POST',
+      headers: {
+        'Origin': 'https://attacker.pages.dev'
+      }
+    });
+
+    const result = validateCSRF(request, { trustedOrigins });
+    // This expectation should FAIL with the current vulnerable code
+    expect(result.valid).toBe(false);
+  });
+
+  it('should correctly handle normalized origins with trailing slashes', () => {
+    const trustedOrigins = ['https://myapp.com/'];
+    const request = new Request('https://myapp.com/api/action', {
+      method: 'POST',
+      headers: {
+        'Origin': 'https://myapp.com'
+      }
+    });
+
+    const result = validateCSRF(request, { trustedOrigins });
+    expect(result.valid).toBe(true);
+  });
+
+  it('should allow GET requests without origin validation', () => {
+    const request = new Request('https://myapp.com/api/data', {
+      method: 'GET'
+    });
+
+    const result = validateCSRF(request);
+    expect(result.valid).toBe(true);
+  });
+});


### PR DESCRIPTION
Identified and fixed a high-priority CSRF vulnerability. The previous implementation erroneously trusted any subdomain on Vercel or Cloudflare Pages if at least one such domain was in the trusted list. This allowed an attacker to bypass CSRF protection by hosting a malicious site on their own subdomain of the same platform. I have enforced strict exact matching for origins and added tests to prevent regressions.

---
*PR created automatically by Jules for task [6125301299866732246](https://jules.google.com/task/6125301299866732246) started by @cpa03*