### PR TITLE
🛡️ Sentinel: Fix CSRF bypass via platform subdomains

### DIFF
--- a/src/lib/security/csrf.ts
+++ b/src/lib/security/csrf.ts
@@ -77,20 +77,6 @@ function isTrustedOrigin(origin: string, trustedOrigins: string[]): boolean {
     if (normalizedOrigin === normalizedTrusted) {
       return true;
     }
-
-    if (
-      normalizedTrusted.includes('.vercel.app') &&
-      normalizedOrigin.endsWith('.vercel.app')
-    ) {
-      return true;
-    }
-
-    if (
-      normalizedTrusted.includes('.pages.dev') &&
-      normalizedOrigin.endsWith('.pages.dev')
-    ) {
-      return true;
-    }
   }
 
   return false;

--- a/tests/security/csrf.test.ts
+++ b/tests/security/csrf.test.ts
@@ -1,0 +1,86 @@
+import { validateCSRF, CSRF_CONFIG } from '@/lib/security/csrf';
+import { APP_CONFIG } from '@/lib/config/app';
+
+describe('CSRF Protection Security', () => {
+  const originalEnv = process.env.NODE_ENV;
+
+  beforeAll(() => {
+    // CSRF is disabled in 'test' mode by default in CSRF_CONFIG
+    // We need to ensure it's enabled for these tests
+    // @ts-ignore
+    CSRF_CONFIG.ENABLED = true;
+  });
+
+  afterAll(() => {
+    // @ts-ignore
+    CSRF_CONFIG.ENABLED = originalEnv !== 'test';
+  });
+
+  it('should allow trusted origins', () => {
+    const trustedOrigin = APP_CONFIG.URLS.BASE;
+    const request = new Request('https://api.ideaflow.com/api/ideas', {
+      method: 'POST',
+      headers: {
+        'origin': trustedOrigin
+      }
+    });
+
+    const result = validateCSRF(request);
+    expect(result.valid).toBe(true);
+  });
+
+  it('should block untrusted origins', () => {
+    const request = new Request('https://api.ideaflow.com/api/ideas', {
+      method: 'POST',
+      headers: {
+        'origin': 'https://evil.com'
+      }
+    });
+
+    const result = validateCSRF(request);
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('Invalid origin header');
+  });
+
+  it('VULNERABILITY REPRODUCTION: should NOT allow untrusted subdomains on same platform', () => {
+    // This test currently FAILS (returns valid: true) because of the broad suffix matching
+    // We want it to be FALSE after our fix
+
+    const platformTrustedOrigin = 'https://myapp.vercel.app';
+    const maliciousSubdomain = 'https://attacker.vercel.app';
+
+    const request = new Request('https://myapp.vercel.app/api/ideas', {
+      method: 'POST',
+      headers: {
+        'origin': maliciousSubdomain
+      }
+    });
+
+    // Mocking trusted origins to include a vercel.app one
+    const result = validateCSRF(request, {
+      trustedOrigins: [platformTrustedOrigin]
+    });
+
+    // In the vulnerable version, this is TRUE
+    // We want it to be FALSE
+    expect(result.valid).toBe(false);
+  });
+
+  it('VULNERABILITY REPRODUCTION: should NOT allow untrusted Cloudflare subdomains', () => {
+    const platformTrustedOrigin = 'https://myapp.pages.dev';
+    const maliciousSubdomain = 'https://attacker.pages.dev';
+
+    const request = new Request('https://myapp.pages.dev/api/ideas', {
+      method: 'POST',
+      headers: {
+        'origin': maliciousSubdomain
+      }
+    });
+
+    const result = validateCSRF(request, {
+      trustedOrigins: [platformTrustedOrigin]
+    });
+
+    expect(result.valid).toBe(false);
+  });
+});


### PR DESCRIPTION
This PR hardens the application's CSRF protection by removing unsafe suffix-based origin matching for Vercel and Cloudflare Pages subdomains.

Previously, the `isTrustedOrigin` function would return `true` if an incoming request's `Origin` header ended with `.vercel.app` or `.pages.dev`, provided that at least one trusted origin was also on that platform. This allowed any attacker with their own site on Vercel or Cloudflare to perform cross-site request forgery against the application.

The fix enforces strict exact matching for all trusted origins.

### Changes:
- **`src/lib/security/csrf.ts`**: Removed the `endsWith('.vercel.app')` and `endsWith('.pages.dev')` logic.
- **`tests/security/csrf.test.ts`**: New test suite demonstrating the vulnerability and confirming the fix.
- **`.jules/sentinel.md`**: Added a security journal entry for this finding.

### Verification:
- Created a reproduction script that confirmed the bypass on the old code.
- Verified that the new code correctly blocks untrusted subdomains on the same platform.
- Ran the security-check.sh script.


---
*PR created automatically by Jules for task [14587193834371912281](https://jules.google.com/task/14587193834371912281) started by @cpa03*