### PR TITLE
⚡ Bolt: optimize `cn` utility with fast-paths

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,7 +1,29 @@
 import { type ClassValue, clsx } from 'clsx';
 import { twMerge } from 'tailwind-merge';
 
+/**
+ * Utility for merging Tailwind classes with clsx and tailwind-merge.
+ *
+ * PERFORMANCE: This function includes fast-paths for common use cases:
+ * 1. Empty calls: Returns an empty string immediately.
+ * 2. Single simple class: If a single string without whitespace is provided,
+ *    it bypasses both clsx and tailwind-merge overhead.
+ *
+ * This results in significant performance gains for components that frequently
+ * call cn() with simple or no arguments.
+ */
 export function cn(...inputs: ClassValue[]) {
+  // FAST-PATH: Empty input
+  if (inputs.length === 0) return '';
+
+  // FAST-PATH: Single simple class string
+  if (inputs.length === 1 && typeof inputs[0] === 'string') {
+    const str = inputs[0];
+    if (str && !/\s/.test(str)) {
+      return str;
+    }
+  }
+
   return twMerge(clsx(inputs));
 }
 


### PR DESCRIPTION
Identified and implemented a performance optimization for the `cn` utility function. Added fast-paths for empty inputs and single simple class strings to bypass `clsx` and `tailwind-merge` overhead. Verified the fix with benchmarks and correctness tests.

---
*PR created automatically by Jules for task [363650878759077746](https://jules.google.com/task/363650878759077746) started by @cpa03*