### PR TITLE
🎨 Palette: Keyboard Shortcuts Modal UX Enhancements

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -12,3 +12,7 @@
 ## 2026-02-25 - [Tooltip for Icon-Only Clear Button]
 **Learning:** Adding a tooltip to icon-only buttons (like a "Clear" button in an input field) provides essential context for users before they interact with it. To prevent the `Tooltip` component's `relative inline-flex` styles from disrupting the `absolute` positioning of elements within an input container, the `Tooltip` should be wrapped in an `absolute` positioned `div` that mirrors the original element's placement.
 **Action:** Always wrap `Tooltip` in an `absolute` positioned container when used for elements that require precise absolute placement within a parent.
+
+## 2026-03-12 - [Search Empty States for Modals]
+**Learning:** Search-driven modals (like command palettes or shortcut help) often fail to guide the user when filtering results in no matches. Providing a specific "No results" state with an icon, context-aware message, and a clear "Clear search" CTA significantly improves error recovery and reduces user frustration.
+**Action:** Always implement a dedicated empty state for filtering/search logic in UI components to ensure the user is never left with a blank screen.

--- a/src/components/KeyboardShortcutsHelp.tsx
+++ b/src/components/KeyboardShortcutsHelp.tsx
@@ -9,6 +9,7 @@ import React, {
   useMemo,
 } from 'react';
 import { ANIMATION_CONFIG } from '@/lib/config/constants';
+import Tooltip from './Tooltip';
 
 export interface KeyboardShortcut {
   keys: string[];
@@ -387,7 +388,7 @@ function KeyboardShortcutsHelpComponent({
       aria-labelledby="keyboard-shortcuts-title"
     >
       <div
-        className={`absolute inset-0 bg-black transition-opacity duration-300 ${isLeaving ? 'opacity-0' : 'opacity-50'}`}
+        className={`absolute inset-0 bg-black backdrop-blur-sm transition-opacity duration-300 ${isLeaving ? 'opacity-0' : 'opacity-50'}`}
         aria-hidden="true"
       />
       <div
@@ -468,54 +469,92 @@ function KeyboardShortcutsHelpComponent({
               </p>
             </div>
           </div>
-          <button
-            ref={closeButtonRef}
-            onClick={handleClose}
-            className="p-2 text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2"
-            aria-label="Close command palette"
-          >
-            <svg
-              className="w-5 h-5"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              strokeWidth={2}
+          <Tooltip content="Close (Esc)" position="left">
+            <button
+              ref={closeButtonRef}
+              onClick={handleClose}
+              className="p-2 text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2"
+              aria-label="Close command palette"
             >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M6 18L18 6M6 6l12 12"
-              />
-            </svg>
-          </button>
+              <svg
+                className="w-5 h-5"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={2}
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M6 18L18 6M6 6l12 12"
+                />
+              </svg>
+            </button>
+          </Tooltip>
         </div>
 
         {/* Shortcuts List */}
         <div className="overflow-y-auto max-h-[60vh] p-6">
-          {Object.entries(groupedShortcuts).map(([context, shortcuts]) => (
-            <div key={context} className="mb-6 last:mb-0">
-              <h3 className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-3">
-                {contextLabels[context as KeyboardShortcut['context']]}
-              </h3>
-              <div className="space-y-1">
-                {shortcuts.map((shortcut, index) => {
-                  const globalIndex = flatShortcuts.findIndex(
-                    (s) => s.description === shortcut.description
-                  );
-                  return (
-                    <ShortcutRow
-                      key={`${context}-${index}`}
-                      shortcut={shortcut}
-                      isMac={isMac}
-                      isSelected={
-                        preferences.vimMode && globalIndex === selectedIndex
-                      }
-                    />
-                  );
-                })}
+          {Object.keys(groupedShortcuts).length > 0 ? (
+            Object.entries(groupedShortcuts).map(([context, shortcuts]) => (
+              <div key={context} className="mb-6 last:mb-0">
+                <h3 className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-3">
+                  {contextLabels[context as KeyboardShortcut['context']]}
+                </h3>
+                <div className="space-y-1">
+                  {shortcuts.map((shortcut, index) => {
+                    const globalIndex = flatShortcuts.findIndex(
+                      (s) => s.description === shortcut.description
+                    );
+                    return (
+                      <ShortcutRow
+                        key={`${context}-${index}`}
+                        shortcut={shortcut}
+                        isMac={isMac}
+                        isSelected={
+                          preferences.vimMode && globalIndex === selectedIndex
+                        }
+                      />
+                    );
+                  })}
+                </div>
               </div>
+            ))
+          ) : (
+            <div className="flex flex-col items-center justify-center py-12 px-4 text-center">
+              <div className="p-4 bg-gray-50 rounded-full mb-4">
+                <svg
+                  className="w-8 h-8 text-gray-400"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={1.5}
+                    d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0zM10 7v3m0 4h.01"
+                  />
+                </svg>
+              </div>
+              <h3 className="text-lg font-medium text-gray-900 mb-1">
+                No commands found
+              </h3>
+              <p className="text-sm text-gray-500 mb-6 max-w-xs">
+                We couldn&apos;t find any shortcuts matching &quot;{searchQuery}
+                &quot;.
+              </p>
+              <button
+                onClick={() => {
+                  setSearchQuery('');
+                  searchInputRef.current?.focus();
+                }}
+                className="inline-flex items-center px-4 py-2 text-sm font-medium text-primary-600 bg-primary-50 hover:bg-primary-100 rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
+              >
+                Clear search
+              </button>
             </div>
-          ))}
+          )}
         </div>
 
         {/* Footer */}


### PR DESCRIPTION
This PR implements a set of micro-UX improvements for the `KeyboardShortcutsHelp` (Command Palette) component:

1. **Visual Polish**: Added `backdrop-blur-sm` to the modal backdrop overlay. This matches the application's design patterns for overlays (like in `LoadingOverlay`) and helps provide better visual separation between the modal and the underlying content.
2. **Accessibility & Clarity**: Wrapped the icon-only 'Close' button in a `Tooltip`. While it already had an `aria-label`, the tooltip provides a visual hint for mouse users and explicitly mentions the "Esc" keyboard shortcut, making the UI more self-documenting.
3. **Error Recovery (Empty State)**: Implemented a dedicated empty state for the search filter. Previously, if a user typed a query that matched no shortcuts, the modal would simply show a blank list. Now, it displays a "No commands found" message with a prominent "Clear search" CTA that returns focus to the search input, guiding the user back to a successful state.

These changes were verified visually using Playwright and via existing accessibility test suites. Critical UX learnings regarding search empty states were recorded in `.jules/palette.md`.

---
*PR created automatically by Jules for task [9797854348898015592](https://jules.google.com/task/9797854348898015592) started by @cpa03*