### PR TITLE
🛡️ Sentinel: [HIGH] Fix CSRF suffix matching vulnerability

### DIFF
--- a/src/lib/security/csrf.ts
+++ b/src/lib/security/csrf.ts
@@ -78,19 +78,6 @@ function isTrustedOrigin(origin: string, trustedOrigins: string[]): boolean {
       return true;
     }
 
-    if (
-      normalizedTrusted.includes('.vercel.app') &&
-      normalizedOrigin.endsWith('.vercel.app')
-    ) {
-      return true;
-    }
-
-    if (
-      normalizedTrusted.includes('.pages.dev') &&
-      normalizedOrigin.endsWith('.pages.dev')
-    ) {
-      return true;
-    }
   }
 
   return false;


### PR DESCRIPTION
The CSRF protection mechanism was vulnerable to origin spoofing on multi-tenant platforms like Vercel and Cloudflare Pages. By using `.endsWith('.vercel.app')`, any site hosted on Vercel could bypass CSRF checks. This PR removes that logic and enforces exact origin matching.

Severity: HIGH
Vulnerability: CSRF Origin Validation Bypass
Impact: Cross-site request forgery attacks from other sites on the same platform.
Fix: Removed suffix-based matching in `isTrustedOrigin`.
Verification: Verified using a standalone reproduction script `reproduce_csrf.ts`.


---
*PR created automatically by Jules for task [1475787339623198409](https://jules.google.com/task/1475787339623198409) started by @cpa03*