### PR TITLE
🎨 Palette: add backdrop blur to mobile navigation backdrop

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -12,3 +12,7 @@
 ## 2026-02-25 - [Tooltip for Icon-Only Clear Button]
 **Learning:** Adding a tooltip to icon-only buttons (like a "Clear" button in an input field) provides essential context for users before they interact with it. To prevent the `Tooltip` component's `relative inline-flex` styles from disrupting the `absolute` positioning of elements within an input container, the `Tooltip` should be wrapped in an `absolute` positioned `div` that mirrors the original element's placement.
 **Action:** Always wrap `Tooltip` in an `absolute` positioned container when used for elements that require precise absolute placement within a parent.
+
+## 2026-03-17 - [Backdrop Blur for Navigation Overlays]
+**Learning:** Adding `backdrop-blur-sm` to full-screen or large navigation overlays improves visual hierarchy and focus by subtly obscuring the content below without completely hiding context. This provides a more modern, high-quality feel compared to simple solid or semi-transparent backgrounds and ensures consistency across the application's loading and navigation layers.
+**Action:** Apply `backdrop-blur-sm` to all major overlay backdrops (Modals, Navigation Drawers, Full-screen Loaders) for a consistent and polished UI.

--- a/src/components/MobileNav.tsx
+++ b/src/components/MobileNav.tsx
@@ -193,7 +193,7 @@ function MobileNavComponent() {
         <>
           {/* Backdrop overlay */}
           <div
-            className="fixed inset-0 top-16 bg-black bg-opacity-50 z-[99] fade-in"
+            className="fixed inset-0 top-16 bg-black/50 backdrop-blur-sm z-[99] fade-in"
             onClick={closeMenu}
             onTouchEnd={closeMenu}
             aria-hidden="true"


### PR DESCRIPTION
💡 What: Added `backdrop-blur-sm` effect to the mobile navigation backdrop overlay in `src/components/MobileNav.tsx`.

🎯 Why: To improve visual hierarchy and separate the navigation layer from the background content. This micro-UX touch provides a more modern, high-quality feel consistent with other overlays in the application (like `LoadingOverlay` and `KeyboardShortcutsHelp`).

📸 After: Verified via Playwright screenshot that the blur effect is correctly applied when the mobile menu is open.

♿ Accessibility: Reduces visual noise from background content while the menu is active, helping users focus on navigation items.

---
*PR created automatically by Jules for task [2814177180773146608](https://jules.google.com/task/2814177180773146608) started by @cpa03*