### PR TITLE
🛡️ Sentinel: [HIGH] Fix CSRF shared domain bypass and harden session IDs

### DIFF
--- a/src/lib/ab-test.ts
+++ b/src/lib/ab-test.ts
@@ -179,7 +179,13 @@ function getDeterministicRandom(experimentId: string): number {
     // Get or create session ID
     let sessionId = sessionStorage.getItem('ideaflow_session_id');
     if (!sessionId) {
-      sessionId = `session_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`;
+      // SECURITY: Use crypto.randomUUID() for cryptographically secure, collision-resistant IDs
+      // Falls back to timestamp-based ID if crypto is not available (rare edge case)
+      try {
+        sessionId = `session_${crypto.randomUUID()}`;
+      } catch {
+        sessionId = `session_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`;
+      }
       sessionStorage.setItem('ideaflow_session_id', sessionId);
     }
 

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -218,7 +218,13 @@ function getSessionId(): string {
   try {
     let sessionId = sessionStorage.getItem(storageKey);
     if (!sessionId) {
-      sessionId = `session_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`;
+      // SECURITY: Use crypto.randomUUID() for cryptographically secure, collision-resistant IDs
+      // Falls back to timestamp-based ID if crypto is not available (rare edge case)
+      try {
+        sessionId = `session_${crypto.randomUUID()}`;
+      } catch {
+        sessionId = `session_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`;
+      }
       sessionStorage.setItem(storageKey, sessionId);
     }
     return sessionId;

--- a/src/lib/security/csrf.ts
+++ b/src/lib/security/csrf.ts
@@ -78,19 +78,16 @@ function isTrustedOrigin(origin: string, trustedOrigins: string[]): boolean {
       return true;
     }
 
-    if (
-      normalizedTrusted.includes('.vercel.app') &&
-      normalizedOrigin.endsWith('.vercel.app')
-    ) {
-      return true;
-    }
-
-    if (
-      normalizedTrusted.includes('.pages.dev') &&
-      normalizedOrigin.endsWith('.pages.dev')
-    ) {
-      return true;
-    }
+    /**
+     * SECURITY: We perform ONLY exact origin matching.
+     *
+     * Previous implementation allowed suffix matching for cloud provider domains
+     * (e.g., .vercel.app, .pages.dev). This is insecure as it allows any site
+     * on the same platform to bypass CSRF protection for our application.
+     *
+     * Exact matching ensures that only our specific deployment origins
+     * can perform state-changing operations.
+     */
   }
 
   return false;

--- a/src/lib/session-analytics.ts
+++ b/src/lib/session-analytics.ts
@@ -33,7 +33,13 @@ function getSessionId(): string {
   try {
     let sessionId = sessionStorage.getItem(storageKey);
     if (!sessionId) {
-      sessionId = `session_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`;
+      // SECURITY: Use crypto.randomUUID() for cryptographically secure, collision-resistant IDs
+      // Falls back to timestamp-based ID if crypto is not available (rare edge case)
+      try {
+        sessionId = `session_${crypto.randomUUID()}`;
+      } catch {
+        sessionId = `session_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`;
+      }
       sessionStorage.setItem(storageKey, sessionId);
     }
     return sessionId;


### PR DESCRIPTION
### 🛡️ Sentinel: [HIGH] Fix CSRF shared domain bypass and harden session IDs

🚨 **Severity:** HIGH

💡 **Vulnerability:** 
1. **CSRF Bypass:** The CSRF protection mechanism used suffix-based matching for `*.vercel.app` and `*.pages.dev` domains. This allowed any other application hosted on these platforms to bypass CSRF origin checks for our application.
2. **Weak ID Generation:** Session IDs were generated using `Math.random()`, which is not cryptographically secure and can lead to predictable identifiers or collisions in high-traffic scenarios.

🎯 **Impact:** 
- An attacker with a site on the same platform could perform state-changing operations on behalf of users.
- Predictable session IDs could potentially lead to session fixation or information leakage across analytics events.

🔧 **Fix:** 
- Enforced exact origin matching in `src/lib/security/csrf.ts`.
- Implemented `crypto.randomUUID()` for session ID generation in `src/lib/session-analytics.ts`, `src/lib/analytics.ts`, and `src/lib/ab-test.ts` with a robust fallback.

✅ **Verification:** 
- Verified logic removal in `src/lib/security/csrf.ts`.
- Verified UUID implementation in all session tracking files.
- Ran `npm run security:check` and `npm run lint` successfully.

Learnings have been recorded in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [17274219164034792657](https://jules.google.com/task/17274219164034792657) started by @cpa03*