### PR TITLE
🛡️ Sentinel: [HIGH] Fix CSRF origin validation bypass

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,5 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/lib/security/csrf.ts
+++ b/src/lib/security/csrf.ts
@@ -78,19 +78,6 @@ function isTrustedOrigin(origin: string, trustedOrigins: string[]): boolean {
       return true;
     }
 
-    if (
-      normalizedTrusted.includes('.vercel.app') &&
-      normalizedOrigin.endsWith('.vercel.app')
-    ) {
-      return true;
-    }
-
-    if (
-      normalizedTrusted.includes('.pages.dev') &&
-      normalizedOrigin.endsWith('.pages.dev')
-    ) {
-      return true;
-    }
   }
 
   return false;


### PR DESCRIPTION
### 🛡️ Sentinel Security Fix

**🚨 Severity:** HIGH
**💡 Vulnerability:** CSRF Origin Validation Bypass via Suffix Matching
**🎯 Impact:** Any user with a subdomain on Vercel or Cloudflare Pages could bypass CSRF protections for other applications hosted on the same platform. This allowed unauthorized state-changing requests (POST, PUT, DELETE, etc.) to be performed on behalf of authenticated users.
**🔧 Fix:** Removed the insecure logic in `src/lib/security/csrf.ts` that performed suffix-based matching for `.vercel.app` and `.pages.dev`. The system now only allows exact matches against the configured `TRUSTED_ORIGINS`.
**✅ Verification:** 
1. Created a reproduction script `repro_csrf.ts` that simulated a request from `attacker.vercel.app` to a production environment.
2. Verified that before the fix, the origin was trusted.
3. Verified that after the fix, the origin is correctly rejected with a `valid: false` result and logged as a security event.
4. Ran `pnpm test:ci` and all 62 test suites passed.

**Journal Entry Updated:** `.jules/sentinel.md` has been updated with critical learning regarding suffix-based origin matching.

---
*PR created automatically by Jules for task [11178703267298705873](https://jules.google.com/task/11178703267298705873) started by @cpa03*