### PR TITLE
⚡ Bolt: Stabilize handleToggleTaskStatus in useTaskManagement

### DIFF
--- a/src/hooks/useTaskManagement.ts
+++ b/src/hooks/useTaskManagement.ts
@@ -202,11 +202,11 @@ export function useTaskManagement(ideaId: string): UseTaskManagementReturn {
         currentStatus === 'completed' ? 'todo' : 'completed';
 
       // Store previous state for potential rollback
-      previousDataRef.current = data;
+      previousDataRef.current = dataRef.current;
 
       // Find the task for toast message BEFORE making changes
       const findTask = () => {
-        return data?.deliverables
+        return dataRef.current?.deliverables
           .flatMap((d) => d.tasks)
           .find((t) => t.id === taskId);
       };
@@ -293,7 +293,7 @@ export function useTaskManagement(ideaId: string): UseTaskManagementReturn {
         setUpdatingTaskId(null);
       }
     },
-    [data, logger, applyTaskStatusUpdate]
+    [logger, applyTaskStatusUpdate]
   );
 
   // Toggle deliverable expansion


### PR DESCRIPTION
💡 What: Stabilized the `handleToggleTaskStatus` callback in the `useTaskManagement` hook by using a `useRef` to track the latest task data.
🎯 Why: Previously, the callback was recreated on every data update because `data` was in its dependency array. This caused all `DeliverableCard` components (which are memoized) to re-render unnecessarily every time a task status was toggled.
📊 Impact: Reduces re-renders of `DeliverableCard` components during task status updates, leading to a smoother user experience, especially in larger task lists.
🔬 Measurement: Verified by code review and by running existing tests to ensure that the optimistic update and API call logic remains functional while the callback reference stays stable.

---
*PR created automatically by Jules for task [15468490952355928474](https://jules.google.com/task/15468490952355928474) started by @cpa03*