### PR TITLE
🎨 Palette: Keyboard Shortcuts Modal Enhancements

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -12,3 +12,7 @@
 ## 2026-02-25 - [Tooltip for Icon-Only Clear Button]
 **Learning:** Adding a tooltip to icon-only buttons (like a "Clear" button in an input field) provides essential context for users before they interact with it. To prevent the `Tooltip` component's `relative inline-flex` styles from disrupting the `absolute` positioning of elements within an input container, the `Tooltip` should be wrapped in an `absolute` positioned `div` that mirrors the original element's placement.
 **Action:** Always wrap `Tooltip` in an `absolute` positioned container when used for elements that require precise absolute placement within a parent.
+
+## 2026-03-23 - [Keyboard Shortcuts Modal Enhancements]
+**Learning:** Empty states for search-driven UIs and tooltips for hidden actions (like Esc to close) significantly improve discoverability and feedback. Adding haptic feedback to toggles provides physical confirmation on mobile, while backdrop blur enhances visual focus by reducing background noise.
+**Action:** Always implement descriptive empty states with icons for search filters and use tooltips to reveal secondary interaction methods like keyboard shortcuts on action buttons.

--- a/src/components/KeyboardShortcutsHelp.tsx
+++ b/src/components/KeyboardShortcutsHelp.tsx
@@ -9,6 +9,8 @@ import React, {
   useMemo,
 } from 'react';
 import { ANIMATION_CONFIG } from '@/lib/config/constants';
+import { triggerHapticFeedback } from '@/lib/utils';
+import Tooltip from './Tooltip';
 
 export interface KeyboardShortcut {
   keys: string[];
@@ -387,7 +389,7 @@ function KeyboardShortcutsHelpComponent({
       aria-labelledby="keyboard-shortcuts-title"
     >
       <div
-        className={`absolute inset-0 bg-black transition-opacity duration-300 ${isLeaving ? 'opacity-0' : 'opacity-50'}`}
+        className={`absolute inset-0 bg-black backdrop-blur-sm transition-opacity duration-300 ${isLeaving ? 'opacity-0' : 'opacity-50'}`}
         aria-hidden="true"
       />
       <div
@@ -425,9 +427,10 @@ function KeyboardShortcutsHelpComponent({
               <input
                 type="checkbox"
                 checked={preferences.vimMode}
-                onChange={(e) =>
-                  updatePreferences({ vimMode: e.target.checked })
-                }
+                onChange={(e) => {
+                  triggerHapticFeedback();
+                  updatePreferences({ vimMode: e.target.checked });
+                }}
                 className="rounded border-gray-300 text-primary-600 focus:ring-primary-500"
               />
               Enable vim navigation (j/k)
@@ -468,54 +471,83 @@ function KeyboardShortcutsHelpComponent({
               </p>
             </div>
           </div>
-          <button
-            ref={closeButtonRef}
-            onClick={handleClose}
-            className="p-2 text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2"
-            aria-label="Close command palette"
-          >
-            <svg
-              className="w-5 h-5"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              strokeWidth={2}
+          <Tooltip content="Close (Esc)" position="bottom">
+            <button
+              ref={closeButtonRef}
+              onClick={handleClose}
+              className="p-2 text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2"
+              aria-label="Close command palette"
             >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M6 18L18 6M6 6l12 12"
-              />
-            </svg>
-          </button>
+              <svg
+                className="w-5 h-5"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={2}
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M6 18L18 6M6 6l12 12"
+                />
+              </svg>
+            </button>
+          </Tooltip>
         </div>
 
         {/* Shortcuts List */}
         <div className="overflow-y-auto max-h-[60vh] p-6">
-          {Object.entries(groupedShortcuts).map(([context, shortcuts]) => (
-            <div key={context} className="mb-6 last:mb-0">
-              <h3 className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-3">
-                {contextLabels[context as KeyboardShortcut['context']]}
-              </h3>
-              <div className="space-y-1">
-                {shortcuts.map((shortcut, index) => {
-                  const globalIndex = flatShortcuts.findIndex(
-                    (s) => s.description === shortcut.description
-                  );
-                  return (
-                    <ShortcutRow
-                      key={`${context}-${index}`}
-                      shortcut={shortcut}
-                      isMac={isMac}
-                      isSelected={
-                        preferences.vimMode && globalIndex === selectedIndex
-                      }
-                    />
-                  );
-                })}
+          {flatShortcuts.length > 0 ? (
+            Object.entries(groupedShortcuts).map(([context, shortcuts]) => (
+              <div key={context} className="mb-6 last:mb-0">
+                <h3 className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-3">
+                  {contextLabels[context as KeyboardShortcut['context']]}
+                </h3>
+                <div className="space-y-1">
+                  {shortcuts.map((shortcut, index) => {
+                    const globalIndex = flatShortcuts.findIndex(
+                      (s) => s.description === shortcut.description
+                    );
+                    return (
+                      <ShortcutRow
+                        key={`${context}-${index}`}
+                        shortcut={shortcut}
+                        isMac={isMac}
+                        isSelected={
+                          preferences.vimMode && globalIndex === selectedIndex
+                        }
+                      />
+                    );
+                  })}
+                </div>
               </div>
+            ))
+          ) : (
+            <div className="py-12 flex flex-col items-center justify-center text-center animate-in fade-in zoom-in duration-300">
+              <div className="bg-gray-100 p-4 rounded-full mb-4">
+                <svg
+                  className="w-8 h-8 text-gray-400"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={1.5}
+                    d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0zM10 7v3m0 4h.01"
+                  />
+                </svg>
+              </div>
+              <h3 className="text-lg font-medium text-gray-900 mb-1">
+                No results found
+              </h3>
+              <p className="text-sm text-gray-500 max-w-xs">
+                We couldn&apos;t find any shortcuts matching &quot;
+                {searchQuery}&quot;
+              </p>
             </div>
-          ))}
+          )}
         </div>
 
         {/* Footer */}


### PR DESCRIPTION
### 💡 What:
Added several micro-UX improvements to the `KeyboardShortcutsHelp` (Command Palette) component:
- **Visual Polish:** Added `backdrop-blur-sm` to the modal backdrop to improve focus on the modal content.
- **Accessibility:** Wrapped the icon-only close button in a `Tooltip` that provides context and informs users about the `Esc` keyboard shortcut.
- **Empty State:** Implemented a dedicated "No results found" state for the search filter with a centered icon and helpful messaging.
- **Interactive Feedback:** Integrated `triggerHapticFeedback` into the Vim mode toggle to provide tactile confirmation on supported devices.

### 🎯 Why:
The command palette is a central navigation and utility hub. These enhancements make it feel more integrated with the design system, provide better feedback during search, and improve discoverability of its primary interaction patterns.

### ♿ Accessibility:
- Provided an explicit label and shortcut hint via Tooltip for the close button.
- Improved screen reader feedback for empty search results.
- Enhanced visual focus through backdrop blurring.

### 📸 Before/After:
(Screenshots attached in verification)
- **Modal with blur:** `/home/jules/verification/shortcuts_modal_blur.png`
- **Empty State:** `/home/jules/verification/shortcuts_empty_state.png`

---
*PR created automatically by Jules for task [15053781354367882553](https://jules.google.com/task/15053781354367882553) started by @cpa03*