### PR TITLE
🎨 Palette: Add tooltips to Alert and Onboarding dismissal buttons

### DIFF
--- a/src/components/Alert.tsx
+++ b/src/components/Alert.tsx
@@ -3,6 +3,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { ANIMATION_CONFIG } from '@/lib/config/constants';
 import { ALERT_STYLES, ALERT_BASE_STYLES } from '@/lib/config';
+import Tooltip from './Tooltip';
 
 interface AlertProps {
   type: 'error' | 'warning' | 'info' | 'success';
@@ -109,27 +110,29 @@ const AlertComponent = function Alert({
         <div className={styles.textColor}>{children}</div>
       </div>
       {onClose && (
-        <button
-          onClick={handleClose}
-          className={`${ALERT_BASE_STYLES.closeButton} ${styles.textColor} ${styles.focusRing}`}
-          aria-label="Dismiss alert"
-          type="button"
-        >
-          <svg
-            className="w-4 h-4"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-            strokeWidth={2}
-            aria-hidden="true"
+        <Tooltip content="Dismiss alert" position="top" className="flex-shrink-0">
+          <button
+            onClick={handleClose}
+            className={`${ALERT_BASE_STYLES.closeButton} ${styles.textColor} ${styles.focusRing}`}
+            aria-label="Dismiss alert"
+            type="button"
           >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              d="M6 18L18 6M6 6l12 12"
-            />
-          </svg>
-        </button>
+            <svg
+              className="w-4 h-4"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        </Tooltip>
       )}
     </div>
   );

--- a/src/components/UserOnboarding.tsx
+++ b/src/components/UserOnboarding.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import { trackEvent, ANALYTICS_EVENTS } from '@/lib/analytics';
+import Tooltip from './Tooltip';
 
 /**
  * Onboarding Tour Steps
@@ -265,26 +266,30 @@ export default function UserOnboarding() {
         />
 
         {/* Close button */}
-        <button
-          onClick={handleSkip}
-          className="absolute top-3 right-3 text-gray-400 hover:text-gray-600 transition-colors p-1"
-          aria-label="Skip onboarding tour"
-        >
-          <svg
-            className="w-5 h-5"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-            aria-hidden="true"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M6 18L18 6M6 6l12 12"
-            />
-          </svg>
-        </button>
+        <div className="absolute top-3 right-3">
+          <Tooltip content="Skip tour" position="bottom">
+            <button
+              onClick={handleSkip}
+              className="text-gray-400 hover:text-gray-600 transition-colors p-1"
+              aria-label="Skip onboarding tour"
+            >
+              <svg
+                className="w-5 h-5"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M6 18L18 6M6 6l12 12"
+                />
+              </svg>
+            </button>
+          </Tooltip>
+        </div>
 
         {/* Content */}
         <div className="mt-2">


### PR DESCRIPTION
### 💡 What
Added `Tooltip` components to icon-only interactive elements in the `Alert` and `UserOnboarding` components.

### 🎯 Why
Icon-only buttons, while clean, can sometimes lack immediate context for users. Adding tooltips provides a clear, non-intrusive explanation of the button's action on hover or focus, making the interface more intuitive and pleasant to use.

### 📸 Before/After
- **Alert:** The "X" button to dismiss alerts now shows a "Dismiss alert" tooltip.
- **UserOnboarding:** The "X" button to skip the tour now shows a "Skip tour" tooltip.
- *Visual proof of the Onboarding tooltip was verified via Playwright screenshot.*

### ♿ Accessibility
- Provides visual context for icon-only buttons.
- Tooltips are also triggered on focus, aiding keyboard users.
- Maintained existing `aria-label` attributes for screen reader compatibility.
- Used `flex-shrink-0` and absolute wrapper `div`s to ensure the `Tooltip` component doesn't disrupt established layouts.

---
*PR created automatically by Jules for task [11179799158980024399](https://jules.google.com/task/11179799158980024399) started by @cpa03*