### PR TITLE
🎨 Palette: Enhance Alert accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -12,3 +12,7 @@
 ## 2026-02-25 - [Tooltip for Icon-Only Clear Button]
 **Learning:** Adding a tooltip to icon-only buttons (like a "Clear" button in an input field) provides essential context for users before they interact with it. To prevent the `Tooltip` component's `relative inline-flex` styles from disrupting the `absolute` positioning of elements within an input container, the `Tooltip` should be wrapped in an `absolute` positioned `div` that mirrors the original element's placement.
 **Action:** Always wrap `Tooltip` in an `absolute` positioned container when used for elements that require precise absolute placement within a parent.
+
+## 2026-02-26 - [Tooltip for Icon-Only Dismiss Button in Flex Containers]
+**Learning:** Wrapping icon-only buttons in `Tooltip` within flex containers (like in the `Alert` component) can disrupt the layout if spacing classes (e.g., `ml-2`, `flex-shrink-0`) remain on the button itself. Moving these layout-affecting classes to the `Tooltip` component's `className` prop ensures the flex parent correctly positions the tooltip wrapper and maintains the intended visual spacing.
+**Action:** When wrapping a flex child in a `Tooltip`, apply layout-impacting classes to the `Tooltip` component rather than the child button.

--- a/src/components/Alert.tsx
+++ b/src/components/Alert.tsx
@@ -3,6 +3,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { ANIMATION_CONFIG } from '@/lib/config/constants';
 import { ALERT_STYLES, ALERT_BASE_STYLES } from '@/lib/config';
+import Tooltip from './Tooltip';
 
 interface AlertProps {
   type: 'error' | 'warning' | 'info' | 'success';
@@ -109,27 +110,33 @@ const AlertComponent = function Alert({
         <div className={styles.textColor}>{children}</div>
       </div>
       {onClose && (
-        <button
-          onClick={handleClose}
-          className={`${ALERT_BASE_STYLES.closeButton} ${styles.textColor} ${styles.focusRing}`}
-          aria-label="Dismiss alert"
-          type="button"
+        <Tooltip
+          content="Dismiss alert"
+          position="top"
+          className="flex-shrink-0 ml-2"
         >
-          <svg
-            className="w-4 h-4"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-            strokeWidth={2}
-            aria-hidden="true"
+          <button
+            onClick={handleClose}
+            className={`${ALERT_BASE_STYLES.closeButton} ${styles.textColor} ${styles.focusRing}`}
+            aria-label="Dismiss alert"
+            type="button"
           >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              d="M6 18L18 6M6 6l12 12"
-            />
-          </svg>
-        </button>
+            <svg
+              className="w-4 h-4"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        </Tooltip>
       )}
     </div>
   );

--- a/src/lib/config/theme.ts
+++ b/src/lib/config/theme.ts
@@ -528,7 +528,7 @@ export const ALERT_BASE_STYLES = {
   visible: 'opacity-100 scale-100 translate-y-0',
   exiting: 'opacity-0 scale-[0.98] translate-y-[-8px]',
   closeButton:
-    'flex-shrink-0 ml-2 hover:opacity-75 focus:outline-none rounded-md p-1 min-h-[32px] min-w-[32px] transition-opacity',
+    'hover:opacity-75 focus:outline-none rounded-md p-1 min-h-[32px] min-w-[32px] transition-opacity',
 } as const;
 
 /**


### PR DESCRIPTION
### 💡 What: The UX enhancement added
Added a visual `Tooltip` to the icon-only "Dismiss alert" button in the `Alert` component. This provides a clear textual label on hover and focus, complementing the existing `aria-label`.

### 🎯 Why: The user problem it solves
Icon-only buttons can be ambiguous for some users. Providing a tooltip clarifies the action ("Dismiss alert") before the user interacts with it, making the interface more intuitive and accessible.

### ♿ Accessibility: Any a11y improvements made
- The `Tooltip` reinforces the button's purpose for sighted keyboard and mouse users.
- The `Tooltip` is correctly linked via `aria-describedby` in the underlying component.
- Carefully managed flexbox layout by moving `flex-shrink-0` and `ml-2` to the `Tooltip` wrapper, ensuring the button remains easily targetable and correctly positioned.

### 📸 Before/After: Screenshots
See the attached verification screenshot at `/home/jules/verification/alert_tooltip.png`.

### 📝 Learnings
Recorded in `.jules/palette.md`: Wrapping flex children in a `Tooltip` requires moving layout-affecting classes from the child to the `Tooltip` component to maintain parent flex container integrity.

---
*PR created automatically by Jules for task [12135838799420588369](https://jules.google.com/task/12135838799420588369) started by @cpa03*