### PR TITLE
🎨 Palette: Add tooltip to Alert dismiss button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -12,3 +12,7 @@
 ## 2026-02-25 - [Tooltip for Icon-Only Clear Button]
 **Learning:** Adding a tooltip to icon-only buttons (like a "Clear" button in an input field) provides essential context for users before they interact with it. To prevent the `Tooltip` component's `relative inline-flex` styles from disrupting the `absolute` positioning of elements within an input container, the `Tooltip` should be wrapped in an `absolute` positioned `div` that mirrors the original element's placement.
 **Action:** Always wrap `Tooltip` in an `absolute` positioned container when used for elements that require precise absolute placement within a parent.
+
+## 2026-03-27 - [Preserving Flex Layout when Wrapping with Tooltips]
+**Learning:** When wrapping an icon-only button (or any element) with a `Tooltip` component within a flex container, layout-impacting classes such as `flex-shrink-0` or margins must be applied to the `Tooltip`'s `className` prop rather than the inner button. Since the `Tooltip` becomes the new direct child of the flex container, classes applied only to the inner button will not correctly influence the parent's flex layout.
+**Action:** Always move layout-critical classes to the `Tooltip` wrapper when adding tooltips to components inside flex layouts.

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -130,7 +130,7 @@ export default function LoginPage() {
 
         <form className="mt-8 space-y-6" onSubmit={handleSubmit}>
           {error && (
-            <Alert type="error" title="Sign In Error">
+            <Alert type="error" title="Sign In Error" onClose={() => setError(null)}>
               {error}
             </Alert>
           )}

--- a/src/components/Alert.tsx
+++ b/src/components/Alert.tsx
@@ -3,6 +3,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { ANIMATION_CONFIG } from '@/lib/config/constants';
 import { ALERT_STYLES, ALERT_BASE_STYLES } from '@/lib/config';
+import Tooltip from './Tooltip';
 
 interface AlertProps {
   type: 'error' | 'warning' | 'info' | 'success';
@@ -109,27 +110,33 @@ const AlertComponent = function Alert({
         <div className={styles.textColor}>{children}</div>
       </div>
       {onClose && (
-        <button
-          onClick={handleClose}
-          className={`${ALERT_BASE_STYLES.closeButton} ${styles.textColor} ${styles.focusRing}`}
-          aria-label="Dismiss alert"
-          type="button"
+        <Tooltip
+          content="Dismiss alert"
+          position="top"
+          className="flex-shrink-0 ml-2"
         >
-          <svg
-            className="w-4 h-4"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-            strokeWidth={2}
-            aria-hidden="true"
+          <button
+            onClick={handleClose}
+            className={`${ALERT_BASE_STYLES.closeButton} ${styles.textColor} ${styles.focusRing}`}
+            aria-label="Dismiss alert"
+            type="button"
           >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              d="M6 18L18 6M6 6l12 12"
-            />
-          </svg>
-        </button>
+            <svg
+              className="w-4 h-4"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        </Tooltip>
       )}
     </div>
   );

--- a/src/lib/config/theme.ts
+++ b/src/lib/config/theme.ts
@@ -528,7 +528,7 @@ export const ALERT_BASE_STYLES = {
   visible: 'opacity-100 scale-100 translate-y-0',
   exiting: 'opacity-0 scale-[0.98] translate-y-[-8px]',
   closeButton:
-    'flex-shrink-0 ml-2 hover:opacity-75 focus:outline-none rounded-md p-1 min-h-[32px] min-w-[32px] transition-opacity',
+    'hover:opacity-75 focus:outline-none rounded-md p-1 min-h-[32px] min-w-[32px] transition-opacity',
 } as const;
 
 /**


### PR DESCRIPTION
This PR implements a micro-UX improvement by adding a tooltip to the icon-only dismiss button in the `Alert` component and enabling the dismiss functionality on the Login page.

💡 **What**: 
- The `Alert` component's close button now has a "Dismiss alert" tooltip.
- The `LoginPage` error alert is now dismissible.
- Layout-impacting classes were moved to the `Tooltip` wrapper in `Alert.tsx` to maintain the flexbox layout of the alert.

🎯 **Why**: 
- Icon-only buttons lack context for some users; tooltips provide this context without cluttering the UI.
- Allowing users to dismiss error alerts on the Login page improves the user experience by giving them control over persistent error messages.

♿ **Accessibility**:
- Added a visible tooltip for sighted users.
- Maintained `aria-label` for screen readers.
- Corrected flex layout hierarchy by moving layout classes to the `Tooltip` wrapper (which is now the direct child of the flex container).

📸 **Before/After**:
- [Before] Close button had no tooltip and could not be dismissed on the login page.
- [After] Hovering the 'X' button shows "Dismiss alert" and clicking it clears the error.

---
*PR created automatically by Jules for task [8282077686600716698](https://jules.google.com/task/8282077686600716698) started by @cpa03*