### PR TITLE
🎨 Palette: Add tooltip to ScrollToTop button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -12,3 +12,7 @@
 ## 2026-02-25 - [Tooltip for Icon-Only Clear Button]
 **Learning:** Adding a tooltip to icon-only buttons (like a "Clear" button in an input field) provides essential context for users before they interact with it. To prevent the `Tooltip` component's `relative inline-flex` styles from disrupting the `absolute` positioning of elements within an input container, the `Tooltip` should be wrapped in an `absolute` positioned `div` that mirrors the original element's placement.
 **Action:** Always wrap `Tooltip` in an `absolute` positioned container when used for elements that require precise absolute placement within a parent.
+
+## 2026-03-28 - [Tooltip for Fixed Position ScrollToTop Button]
+**Learning:** To correctly implement a `Tooltip` for fixed-position elements (like `ScrollToTop`), wrap the `Tooltip` component in a container `div` that carries the positioning classes (e.g., `fixed bottom-8 right-8 z-50`). This prevents CSS conflicts where the `Tooltip` component's internal `relative inline-flex` styling might disrupt the intended fixed placement.
+**Action:** Wrap the `Tooltip` component in a correctly positioned container element (like a `div`) when applying it to fixed or absolutely positioned components to maintain layout integrity.

--- a/src/components/ScrollToTop.tsx
+++ b/src/components/ScrollToTop.tsx
@@ -9,6 +9,7 @@ import React, {
   memo,
 } from 'react';
 import { COMPONENT_DEFAULTS } from '@/lib/config';
+import Tooltip from './Tooltip';
 
 interface ScrollToTopProps {
   showAt?: number;
@@ -110,84 +111,87 @@ function ScrollToTopComponent({
     circumference - (scrollProgress / 100) * circumference;
 
   return (
-    <button
-      onClick={scrollToTop}
-      onKeyDown={handleKeyDown}
-      className={`
-        fixed bottom-8 right-8 z-50
-        w-12 h-12
-        flex items-center justify-center
-        bg-white text-gray-700
-        rounded-full shadow-lg
-        border border-gray-200
-        transition-all duration-300 ease-out
-        hover:bg-gray-50 hover:text-primary-600 hover:shadow-xl hover:scale-110
-        hover:border-primary-200
-        focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2
-        active:scale-95
-        ${prefersReducedMotion ? '' : 'animate-in fade-in slide-in-from-bottom-4 duration-300'}
-        ${className}
-      `}
-      aria-label={`Scroll to top of page (${Math.round(scrollProgress)}% scrolled)`}
-      aria-live="polite"
-      type="button"
-    >
-      {!prefersReducedMotion && (
-        <svg
-          className="absolute inset-0 w-full h-full -rotate-90 pointer-events-none"
-          viewBox="0 0 48 48"
-          aria-hidden="true"
-          role="progressbar"
-          aria-valuenow={Math.round(scrollProgress)}
-          aria-valuemin={0}
-          aria-valuemax={100}
+    <div className={`fixed bottom-8 right-8 z-50`}>
+      <Tooltip content="Scroll to top" position="top">
+        <button
+          onClick={scrollToTop}
+          onKeyDown={handleKeyDown}
+          className={`
+            w-12 h-12
+            flex items-center justify-center
+            bg-white text-gray-700
+            rounded-full shadow-lg
+            border border-gray-200
+            transition-all duration-300 ease-out
+            hover:bg-gray-50 hover:text-primary-600 hover:shadow-xl hover:scale-110
+            hover:border-primary-200
+            focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2
+            active:scale-95
+            ${prefersReducedMotion ? '' : 'animate-in fade-in slide-in-from-bottom-4 duration-300'}
+            ${className}
+          `}
+          aria-label={`Scroll to top of page (${Math.round(scrollProgress)}% scrolled)`}
+          aria-live="polite"
+          type="button"
         >
-          <circle
-            cx="24"
-            cy="24"
-            r="22"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            className="text-gray-100"
-          />
-          <circle
-            cx="24"
-            cy="24"
-            r="22"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
+        {!prefersReducedMotion && (
+          <svg
+            className="absolute inset-0 w-full h-full -rotate-90 pointer-events-none"
+            viewBox="0 0 48 48"
+            aria-hidden="true"
+            role="progressbar"
+            aria-valuenow={Math.round(scrollProgress)}
+            aria-valuemin={0}
+            aria-valuemax={100}
+          >
+            <circle
+              cx="24"
+              cy="24"
+              r="22"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              className="text-gray-100"
+            />
+            <circle
+              cx="24"
+              cy="24"
+              r="22"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              className="text-primary-500 transition-all duration-150 ease-out"
+              style={{
+                strokeDasharray: circumference,
+                strokeDashoffset: strokeDashoffset,
+              }}
+            />
+          </svg>
+        )}
+
+        <svg
+          className={`
+            relative z-10 w-5 h-5 transition-transform duration-200
+            ${prefersReducedMotion ? '' : 'group-hover:-translate-y-0.5'}
+          `}
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2}
+          aria-hidden="true"
+        >
+          <path
             strokeLinecap="round"
-            className="text-primary-500 transition-all duration-150 ease-out"
-            style={{
-              strokeDasharray: circumference,
-              strokeDashoffset: strokeDashoffset,
-            }}
+            strokeLinejoin="round"
+            d="M5 10l7-7m0 0l7 7m-7-7v18"
           />
         </svg>
-      )}
 
-      <svg
-        className={`
-          relative z-10 w-5 h-5 transition-transform duration-200
-          ${prefersReducedMotion ? '' : 'group-hover:-translate-y-0.5'}
-        `}
-        fill="none"
-        viewBox="0 0 24 24"
-        stroke="currentColor"
-        strokeWidth={2}
-        aria-hidden="true"
-      >
-        <path
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          d="M5 10l7-7m0 0l7 7m-7-7v18"
-        />
-      </svg>
-
-      <span className="sr-only">Back to top</span>
-    </button>
+          <span className="sr-only">Back to top</span>
+        </button>
+      </Tooltip>
+    </div>
   );
 }
 


### PR DESCRIPTION
This PR implements a micro-UX enhancement by adding an accessible tooltip to the "Scroll to Top" button. 

### 💡 What
Added a "Scroll to top" tooltip that appears when hovering or focusing on the ScrollToTop button.

### 🎯 Why
Icon-only buttons can be ambiguous for sighted users. While the button had an `aria-label` for screen readers, sighted users benefit from a visual label (tooltip) to confirm the button's purpose before interaction.

### ♿ Accessibility
- Provides a visual text alternative to the icon for sighted users.
- Matches the existing `aria-label` for consistency between visual and screen-reader experiences.
- Maintains keyboard accessibility (tooltip triggers on focus).

### 📸 Verification
- Visual verification performed using Playwright.
- Screenshot and video recorded showing the tooltip appearing correctly.
- Unit tests in `tests/ScrollToTop.test.tsx` passed.
- Linting passed.

---
*PR created automatically by Jules for task [18027194043113858921](https://jules.google.com/task/18027194043113858921) started by @cpa03*