### PR TITLE
🎨 Palette: Add Tooltip to ScrollToTop component

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -12,3 +12,7 @@
 ## 2026-02-25 - [Tooltip for Icon-Only Clear Button]
 **Learning:** Adding a tooltip to icon-only buttons (like a "Clear" button in an input field) provides essential context for users before they interact with it. To prevent the `Tooltip` component's `relative inline-flex` styles from disrupting the `absolute` positioning of elements within an input container, the `Tooltip` should be wrapped in an `absolute` positioned `div` that mirrors the original element's placement.
 **Action:** Always wrap `Tooltip` in an `absolute` positioned container when used for elements that require precise absolute placement within a parent.
+
+## 2026-03-29 - [Tooltip Width and Fixed Position Handling]
+**Learning:** For tooltips on components with `fixed` or `absolute` positioning (like `ScrollToTop`), the `Tooltip` wrapper must be nested within a container that carries the positioning classes to prevent the `Tooltip`'s internal `relative` style from breaking the layout. Additionally, adding `w-max` to the Tooltip's absolute container ensures that short, multi-word labels (e.g., "Back to top") do not wrap prematurely, while `max-w` and `whitespace-normal` still protect against very long content.
+**Action:** Nest `Tooltip` inside a positioned container for fixed/absolute elements and use `w-max` on tooltips to prevent awkward wrapping of short phrases.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,5 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/components/ScrollToTop.tsx
+++ b/src/components/ScrollToTop.tsx
@@ -9,6 +9,7 @@ import React, {
   memo,
 } from 'react';
 import { COMPONENT_DEFAULTS } from '@/lib/config';
+import Tooltip from './Tooltip';
 
 interface ScrollToTopProps {
   showAt?: number;
@@ -110,29 +111,30 @@ function ScrollToTopComponent({
     circumference - (scrollProgress / 100) * circumference;
 
   return (
-    <button
-      onClick={scrollToTop}
-      onKeyDown={handleKeyDown}
-      className={`
-        fixed bottom-8 right-8 z-50
-        w-12 h-12
-        flex items-center justify-center
-        bg-white text-gray-700
-        rounded-full shadow-lg
-        border border-gray-200
-        transition-all duration-300 ease-out
-        hover:bg-gray-50 hover:text-primary-600 hover:shadow-xl hover:scale-110
-        hover:border-primary-200
-        focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2
-        active:scale-95
-        ${prefersReducedMotion ? '' : 'animate-in fade-in slide-in-from-bottom-4 duration-300'}
-        ${className}
-      `}
-      aria-label={`Scroll to top of page (${Math.round(scrollProgress)}% scrolled)`}
-      aria-live="polite"
-      type="button"
-    >
-      {!prefersReducedMotion && (
+    <div className="fixed bottom-8 right-8 z-50">
+      <Tooltip content="Back to top" position="left">
+        <button
+          onClick={scrollToTop}
+          onKeyDown={handleKeyDown}
+          className={`
+            w-12 h-12
+            flex items-center justify-center
+            bg-white text-gray-700
+            rounded-full shadow-lg
+            border border-gray-200
+            transition-all duration-300 ease-out
+            hover:bg-gray-50 hover:text-primary-600 hover:shadow-xl hover:scale-110
+            hover:border-primary-200
+            focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2
+            active:scale-95
+            ${prefersReducedMotion ? '' : 'animate-in fade-in slide-in-from-bottom-4 duration-300'}
+            ${className}
+          `}
+          aria-label={`Scroll to top of page (${Math.round(scrollProgress)}% scrolled)`}
+          aria-live="polite"
+          type="button"
+        >
+          {!prefersReducedMotion && (
         <svg
           className="absolute inset-0 w-full h-full -rotate-90 pointer-events-none"
           viewBox="0 0 48 48"
@@ -186,8 +188,10 @@ function ScrollToTopComponent({
         />
       </svg>
 
-      <span className="sr-only">Back to top</span>
-    </button>
+          <span className="sr-only">Back to top</span>
+        </button>
+      </Tooltip>
+    </div>
   );
 }
 

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -188,7 +188,7 @@ function TooltipComponent({
           ref={tooltipRef}
           role="tooltip"
           className={`
-            absolute z-50 pointer-events-none
+            absolute z-50 pointer-events-none w-max
             ${positionClasses[position]}
             ${prefersReducedMotion ? '' : 'transition-all duration-200 ease-out'}
             ${isVisible ? 'opacity-100 scale-100' : 'opacity-0 scale-95'}


### PR DESCRIPTION
💡 What: Added a "Back to top" tooltip to the icon-only ScrollToTop button.
🎯 Why: Improves discoverability for the progress-circle button which lacked a visible text label for sighted users on hover.
♿ Accessibility: Complements existing ARIA labels and screen reader text by providing visual feedback for mouse/focus users.
🛠️ Global: Enhanced Tooltip component with `w-max` to prevent premature wrapping of short multi-word labels.

---
*PR created automatically by Jules for task [8050243709536113964](https://jules.google.com/task/8050243709536113964) started by @cpa03*