### PR TITLE
⚡ Bolt: stabilize handleToggleTaskStatus in useTaskManagement

### DIFF
--- a/src/hooks/useTaskManagement.ts
+++ b/src/hooks/useTaskManagement.ts
@@ -202,11 +202,11 @@ export function useTaskManagement(ideaId: string): UseTaskManagementReturn {
         currentStatus === 'completed' ? 'todo' : 'completed';
 
       // Store previous state for potential rollback
-      previousDataRef.current = data;
+      previousDataRef.current = dataRef.current;
 
       // Find the task for toast message BEFORE making changes
       const findTask = () => {
-        return data?.deliverables
+        return dataRef.current?.deliverables
           .flatMap((d) => d.tasks)
           .find((t) => t.id === taskId);
       };
@@ -293,7 +293,7 @@ export function useTaskManagement(ideaId: string): UseTaskManagementReturn {
         setUpdatingTaskId(null);
       }
     },
-    [data, logger, applyTaskStatusUpdate]
+    [logger, applyTaskStatusUpdate]
   );
 
   // Toggle deliverable expansion

--- a/tests/hooks/useTaskManagement.test.ts
+++ b/tests/hooks/useTaskManagement.test.ts
@@ -1,0 +1,111 @@
+import { renderHook, act } from '@testing-library/react';
+import { useTaskManagement } from '@/hooks/useTaskManagement';
+import { fetchWithTimeout } from '@/lib/api-client';
+
+// Mock the dependencies
+jest.mock('@/lib/api-client', () => ({
+  fetchWithTimeout: jest.fn(),
+}));
+
+jest.mock('@/lib/logger', () => ({
+  createLogger: jest.fn(() => ({
+    info: jest.fn(),
+    error: jest.fn(),
+    errorWithContext: jest.fn(),
+  })),
+}));
+
+jest.mock('@/lib/utils', () => ({
+  triggerHapticFeedback: jest.fn(),
+}));
+
+describe('useTaskManagement', () => {
+  const ideaId = 'test-idea-id';
+  const mockTasksResponse = {
+    success: true,
+    data: {
+      deliverables: [
+        {
+          id: 'd1',
+          title: 'Deliverable 1',
+          tasks: [
+            { id: 't1', title: 'Task 1', status: 'todo', estimate: 2 },
+          ],
+          progress: 0,
+          completedCount: 0,
+          totalCount: 1,
+          totalHours: 2,
+          completedHours: 0,
+        },
+      ],
+      summary: {
+        totalDeliverables: 1,
+        totalTasks: 1,
+        completedTasks: 0,
+        totalHours: 2,
+        completedHours: 0,
+        overallProgress: 0,
+      },
+    },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (fetchWithTimeout as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue(mockTasksResponse),
+    });
+  });
+
+  it('stabilizes handleToggleTaskStatus callback across data updates', async () => {
+    const { result } = renderHook(() => useTaskManagement(ideaId));
+
+    // Wait for initial fetch
+    await act(async () => {
+      // Small delay to allow useEffect to complete
+      await new Promise(resolve => setTimeout(resolve, 0));
+    });
+
+    const firstCallback = result.current.handleToggleTaskStatus;
+
+    // Simulate a data update by triggering a task toggle
+    // Mock the PATCH response
+    (fetchWithTimeout as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: jest.fn().mockResolvedValue({ success: true }),
+    });
+
+    await act(async () => {
+      await result.current.handleToggleTaskStatus('t1', 'todo');
+    });
+
+    const secondCallback = result.current.handleToggleTaskStatus;
+
+    // The callback reference should be the same
+    expect(firstCallback).toBe(secondCallback);
+  });
+
+  it('updates data correctly when toggling task status', async () => {
+    const { result } = renderHook(() => useTaskManagement(ideaId));
+
+    // Wait for initial fetch
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 0));
+    });
+
+    expect(result.current.data?.summary.completedTasks).toBe(0);
+
+    // Mock the PATCH response
+    (fetchWithTimeout as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: jest.fn().mockResolvedValue({ success: true }),
+    });
+
+    await act(async () => {
+      await result.current.handleToggleTaskStatus('t1', 'todo');
+    });
+
+    expect(result.current.data?.summary.completedTasks).toBe(1);
+    expect(result.current.data?.deliverables[0].tasks[0].status).toBe('completed');
+  });
+});


### PR DESCRIPTION
### 💡 What:
Stabilized the `handleToggleTaskStatus` callback in the `useTaskManagement` hook by using `dataRef.current` and removing `data` from the `useCallback` dependency array.

### 🎯 Why:
Every time a task's status was toggled, the `data` state updated. Because `data` was in the dependency array of `handleToggleTaskStatus`, the callback reference changed. This caused all `DeliverableCard` and `TaskItem` components (which are memoized) to re-render, even if they weren't affected by the specific task update, because they received a "new" `onToggle` function prop.

### 📊 Impact:
- **Reduces re-renders:** The `handleToggleTaskStatus` function reference is now stable across data updates.
- **Enables effective memoization:** Downstream components like `DeliverableCard` and `TaskItem` can now skip re-renders when other parts of the data change, as their props (including the toggle handler) remain stable.
- **Faster UI response:** Reduces the main thread work during task status updates, providing a snappier feel especially with larger task lists.

### 🔬 Measurement:
- Added a new test `tests/hooks/useTaskManagement.test.ts` that explicitly asserts the reference equality of `handleToggleTaskStatus` before and after a state update.
- Verified that all 1500+ tests in the suite pass without regressions.

---
*PR created automatically by Jules for task [12422604113124461395](https://jules.google.com/task/12422604113124461395) started by @cpa03*