### PR TITLE
Fix broken group-hover animations in landing page and scroll-to-top button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -12,3 +12,7 @@
 ## 2026-02-25 - [Tooltip for Icon-Only Clear Button]
 **Learning:** Adding a tooltip to icon-only buttons (like a "Clear" button in an input field) provides essential context for users before they interact with it. To prevent the `Tooltip` component's `relative inline-flex` styles from disrupting the `absolute` positioning of elements within an input container, the `Tooltip` should be wrapped in an `absolute` positioned `div` that mirrors the original element's placement.
 **Action:** Always wrap `Tooltip` in an `absolute` positioned container when used for elements that require precise absolute placement within a parent.
+
+## 2026-04-02 - [Fixing Broken group-hover Animations]
+**Learning:** Tailwind `group-hover` effects on child elements (like icon transitions or color shifts) require the parent interactive element (like an `article` card or `button`) to have the `group` class. In large components, it's easy to omit this class, which silently breaks the intended hover feedback and reduces the "delight" factor of the UI.
+**Action:** When implementing or debugging hover transitions for nested elements, verify that the parent container has the `group` class.

--- a/src/components/ScrollToTop.tsx
+++ b/src/components/ScrollToTop.tsx
@@ -114,6 +114,7 @@ function ScrollToTopComponent({
       onClick={scrollToTop}
       onKeyDown={handleKeyDown}
       className={`
+        group
         fixed bottom-8 right-8 z-50
         w-12 h-12
         flex items-center justify-center

--- a/src/components/WhyChooseSection.tsx
+++ b/src/components/WhyChooseSection.tsx
@@ -15,7 +15,7 @@ function WhyChooseSectionComponent() {
         Why Choose IdeaFlow for Project Planning?
       </h2>
       <div className="grid md:grid-cols-2 gap-6">
-        <article className="flex items-start space-x-3 p-4 rounded-lg bg-white border border-gray-100 shadow-sm hover:shadow-md hover:border-green-200 hover:bg-green-50/30 transition-all duration-200 ease-out motion-reduce:transition-none">
+        <article className="group flex items-start space-x-3 p-4 rounded-lg bg-white border border-gray-100 shadow-sm hover:shadow-md hover:border-green-200 hover:bg-green-50/30 transition-all duration-200 ease-out motion-reduce:transition-none">
           <div
             className="bg-green-100 rounded-full w-6 h-6 flex items-center justify-center flex-shrink-0 mt-1 group-hover:bg-green-200 transition-colors duration-200"
             aria-hidden="true"
@@ -42,7 +42,7 @@ function WhyChooseSectionComponent() {
             </p>
           </div>
         </article>
-        <article className="flex items-start space-x-3 p-4 rounded-lg bg-white border border-gray-100 shadow-sm hover:shadow-md hover:border-green-200 hover:bg-green-50/30 transition-all duration-200 ease-out motion-reduce:transition-none">
+        <article className="group flex items-start space-x-3 p-4 rounded-lg bg-white border border-gray-100 shadow-sm hover:shadow-md hover:border-green-200 hover:bg-green-50/30 transition-all duration-200 ease-out motion-reduce:transition-none">
           <div
             className="bg-green-100 rounded-full w-6 h-6 flex items-center justify-center flex-shrink-0 mt-1 group-hover:bg-green-200 transition-colors duration-200"
             aria-hidden="true"
@@ -69,7 +69,7 @@ function WhyChooseSectionComponent() {
             </p>
           </div>
         </article>
-        <article className="flex items-start space-x-3 p-4 rounded-lg bg-white border border-gray-100 shadow-sm hover:shadow-md hover:border-green-200 hover:bg-green-50/30 transition-all duration-200 ease-out motion-reduce:transition-none">
+        <article className="group flex items-start space-x-3 p-4 rounded-lg bg-white border border-gray-100 shadow-sm hover:shadow-md hover:border-green-200 hover:bg-green-50/30 transition-all duration-200 ease-out motion-reduce:transition-none">
           <div
             className="bg-green-100 rounded-full w-6 h-6 flex items-center justify-center flex-shrink-0 mt-1 group-hover:bg-green-200 transition-colors duration-200"
             aria-hidden="true"
@@ -96,7 +96,7 @@ function WhyChooseSectionComponent() {
             </p>
           </div>
         </article>
-        <article className="flex items-start space-x-3 p-4 rounded-lg bg-white border border-gray-100 shadow-sm hover:shadow-md hover:border-green-200 hover:bg-green-50/30 transition-all duration-200 ease-out motion-reduce:transition-none">
+        <article className="group flex items-start space-x-3 p-4 rounded-lg bg-white border border-gray-100 shadow-sm hover:shadow-md hover:border-green-200 hover:bg-green-50/30 transition-all duration-200 ease-out motion-reduce:transition-none">
           <div
             className="bg-green-100 rounded-full w-6 h-6 flex items-center justify-center flex-shrink-0 mt-1 group-hover:bg-green-200 transition-colors duration-200"
             aria-hidden="true"


### PR DESCRIPTION
Enabled broken hover animations on the landing page's 'Why Choose' cards and the 'Scroll to Top' button. The animations (icon color shifts and translations) were correctly defined with `group-hover:` but were not triggering because the parent elements lacked the required `group` Tailwind class.

Accessibility: Improved visual feedback for interactive elements.
Delight: Restored smooth transitions that make the interface feel more responsive.

---
*PR created automatically by Jules for task [8810869900359681615](https://jules.google.com/task/8810869900359681615) started by @cpa03*