### PR TITLE
🎨 Palette: Enhance ScrollToTop with tooltip and hover feedback

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -12,3 +12,7 @@
 ## 2026-02-25 - [Tooltip for Icon-Only Clear Button]
 **Learning:** Adding a tooltip to icon-only buttons (like a "Clear" button in an input field) provides essential context for users before they interact with it. To prevent the `Tooltip` component's `relative inline-flex` styles from disrupting the `absolute` positioning of elements within an input container, the `Tooltip` should be wrapped in an `absolute` positioned `div` that mirrors the original element's placement.
 **Action:** Always wrap `Tooltip` in an `absolute` positioned container when used for elements that require precise absolute placement within a parent.
+
+## 2026-04-03 - [Tooltip for Fixed Position Elements]
+**Learning:** To correctly implement a Tooltip for fixed-position elements (like `ScrollToTop`), wrap the `Tooltip` component in a container `div` that carries the positioning classes (e.g., `fixed bottom-8 right-8 z-50`). To ensure correct layout consistency and satisfy accessibility tests, apply the component's custom `className` prop to this outermost wrapper `div` rather than the inner interactive element.
+**Action:** When adding tooltips to fixed-position components, use a wrapper `div` for the fixed positioning and pass the `className` prop to it to preserve extensibility.

--- a/src/components/ScrollToTop.tsx
+++ b/src/components/ScrollToTop.tsx
@@ -9,6 +9,7 @@ import React, {
   memo,
 } from 'react';
 import { COMPONENT_DEFAULTS } from '@/lib/config';
+import Tooltip from './Tooltip';
 
 interface ScrollToTopProps {
   showAt?: number;
@@ -110,29 +111,30 @@ function ScrollToTopComponent({
     circumference - (scrollProgress / 100) * circumference;
 
   return (
-    <button
-      onClick={scrollToTop}
-      onKeyDown={handleKeyDown}
-      className={`
-        fixed bottom-8 right-8 z-50
-        w-12 h-12
-        flex items-center justify-center
-        bg-white text-gray-700
-        rounded-full shadow-lg
-        border border-gray-200
-        transition-all duration-300 ease-out
-        hover:bg-gray-50 hover:text-primary-600 hover:shadow-xl hover:scale-110
-        hover:border-primary-200
-        focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2
-        active:scale-95
-        ${prefersReducedMotion ? '' : 'animate-in fade-in slide-in-from-bottom-4 duration-300'}
-        ${className}
-      `}
-      aria-label={`Scroll to top of page (${Math.round(scrollProgress)}% scrolled)`}
-      aria-live="polite"
-      type="button"
-    >
-      {!prefersReducedMotion && (
+    <div className={`fixed bottom-8 right-8 z-50 ${className}`}>
+      <Tooltip content="Back to top" position="top">
+        <button
+          onClick={scrollToTop}
+          onKeyDown={handleKeyDown}
+          className={`
+            group
+            w-12 h-12
+            flex items-center justify-center
+            bg-white text-gray-700
+            rounded-full shadow-lg
+            border border-gray-200
+            transition-all duration-300 ease-out
+            hover:bg-gray-50 hover:text-primary-600 hover:shadow-xl hover:scale-110
+            hover:border-primary-200
+            focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2
+            active:scale-95
+            ${prefersReducedMotion ? '' : 'animate-in fade-in slide-in-from-bottom-4 duration-300'}
+          `}
+          aria-label={`Scroll to top of page (${Math.round(scrollProgress)}% scrolled)`}
+          aria-live="polite"
+          type="button"
+        >
+          {!prefersReducedMotion && (
         <svg
           className="absolute inset-0 w-full h-full -rotate-90 pointer-events-none"
           viewBox="0 0 48 48"
@@ -186,8 +188,10 @@ function ScrollToTopComponent({
         />
       </svg>
 
-      <span className="sr-only">Back to top</span>
-    </button>
+          <span className="sr-only">Back to top</span>
+        </button>
+      </Tooltip>
+    </div>
   );
 }
 

--- a/tests/ScrollToTop.test.tsx
+++ b/tests/ScrollToTop.test.tsx
@@ -95,14 +95,17 @@ describe('ScrollToTop', () => {
     expect(screen.getByText('Back to top')).toBeInTheDocument();
   });
 
-  it('should apply custom className', () => {
+  it('should apply custom className to the outermost container', () => {
     Object.defineProperty(window, 'scrollY', { value: 500, writable: true });
-    render(<ScrollToTop showAt={400} className="custom-class" />);
+    const { container } = render(
+      <ScrollToTop showAt={400} className="custom-class" />
+    );
 
     fireEvent.scroll(window);
-    const button = screen.getByLabelText(/Scroll to top of page/);
 
-    expect(button).toHaveClass('custom-class');
+    const wrapper = container.querySelector('.custom-class');
+    expect(wrapper).toBeInTheDocument();
+    expect(wrapper).toHaveClass('fixed');
   });
 
   it('should use default showAt value of 400', () => {


### PR DESCRIPTION
💡 **What:** Enhanced the `ScrollToTop` component by adding a "Back to top" tooltip and fixing its broken hover animations.

🎯 **Why:** Icon-only buttons benefit from textual affordance via tooltips to ensure their purpose is clear to all users. The hover animation (icon shift) was also broken because the parent element was missing the `group` class required for Tailwind's `group-hover` utility.

♿ **Accessibility:** 
- Retained the existing `aria-label` providing scroll progress context.
- Added visual tooltip text that matches the `sr-only` content.
- Ensured proper focus states and keyboard navigation support.
- Centralized fixed positioning in a wrapper div to ensure consistent hit-area and tooltip placement.

---
*PR created automatically by Jules for task [3452130462395707028](https://jules.google.com/task/3452130462395707028) started by @cpa03*