### PR TITLE
🎨 Palette: Fix missing group classes for hover effects

### DIFF
--- a/src/components/ScrollToTop.tsx
+++ b/src/components/ScrollToTop.tsx
@@ -114,6 +114,7 @@ function ScrollToTopComponent({
       onClick={scrollToTop}
       onKeyDown={handleKeyDown}
       className={`
+        group
         fixed bottom-8 right-8 z-50
         w-12 h-12
         flex items-center justify-center

--- a/src/components/WhyChooseSection.tsx
+++ b/src/components/WhyChooseSection.tsx
@@ -15,7 +15,7 @@ function WhyChooseSectionComponent() {
         Why Choose IdeaFlow for Project Planning?
       </h2>
       <div className="grid md:grid-cols-2 gap-6">
-        <article className="flex items-start space-x-3 p-4 rounded-lg bg-white border border-gray-100 shadow-sm hover:shadow-md hover:border-green-200 hover:bg-green-50/30 transition-all duration-200 ease-out motion-reduce:transition-none">
+        <article className="group flex items-start space-x-3 p-4 rounded-lg bg-white border border-gray-100 shadow-sm hover:shadow-md hover:border-green-200 hover:bg-green-50/30 transition-all duration-200 ease-out motion-reduce:transition-none">
           <div
             className="bg-green-100 rounded-full w-6 h-6 flex items-center justify-center flex-shrink-0 mt-1 group-hover:bg-green-200 transition-colors duration-200"
             aria-hidden="true"
@@ -42,7 +42,7 @@ function WhyChooseSectionComponent() {
             </p>
           </div>
         </article>
-        <article className="flex items-start space-x-3 p-4 rounded-lg bg-white border border-gray-100 shadow-sm hover:shadow-md hover:border-green-200 hover:bg-green-50/30 transition-all duration-200 ease-out motion-reduce:transition-none">
+        <article className="group flex items-start space-x-3 p-4 rounded-lg bg-white border border-gray-100 shadow-sm hover:shadow-md hover:border-green-200 hover:bg-green-50/30 transition-all duration-200 ease-out motion-reduce:transition-none">
           <div
             className="bg-green-100 rounded-full w-6 h-6 flex items-center justify-center flex-shrink-0 mt-1 group-hover:bg-green-200 transition-colors duration-200"
             aria-hidden="true"
@@ -69,7 +69,7 @@ function WhyChooseSectionComponent() {
             </p>
           </div>
         </article>
-        <article className="flex items-start space-x-3 p-4 rounded-lg bg-white border border-gray-100 shadow-sm hover:shadow-md hover:border-green-200 hover:bg-green-50/30 transition-all duration-200 ease-out motion-reduce:transition-none">
+        <article className="group flex items-start space-x-3 p-4 rounded-lg bg-white border border-gray-100 shadow-sm hover:shadow-md hover:border-green-200 hover:bg-green-50/30 transition-all duration-200 ease-out motion-reduce:transition-none">
           <div
             className="bg-green-100 rounded-full w-6 h-6 flex items-center justify-center flex-shrink-0 mt-1 group-hover:bg-green-200 transition-colors duration-200"
             aria-hidden="true"
@@ -96,7 +96,7 @@ function WhyChooseSectionComponent() {
             </p>
           </div>
         </article>
-        <article className="flex items-start space-x-3 p-4 rounded-lg bg-white border border-gray-100 shadow-sm hover:shadow-md hover:border-green-200 hover:bg-green-50/30 transition-all duration-200 ease-out motion-reduce:transition-none">
+        <article className="group flex items-start space-x-3 p-4 rounded-lg bg-white border border-gray-100 shadow-sm hover:shadow-md hover:border-green-200 hover:bg-green-50/30 transition-all duration-200 ease-out motion-reduce:transition-none">
           <div
             className="bg-green-100 rounded-full w-6 h-6 flex items-center justify-center flex-shrink-0 mt-1 group-hover:bg-green-200 transition-colors duration-200"
             aria-hidden="true"


### PR DESCRIPTION
💡 What: Added missing Tailwind `group` classes to `ScrollToTop` and `WhyChooseSection` components.
🎯 Why: Child elements were using `group-hover` utilities without the parent having the `group` class, which meant hover animations and transitions weren't triggering as intended.
📸 Before/After: Icons and arrows now correctly respond to hovering over the parent container.
♿ Accessibility: Provides better visual feedback to users when interacting with these elements.

---
*PR created automatically by Jules for task [17556761591982755955](https://jules.google.com/task/17556761591982755955) started by @cpa03*