### PR TITLE
⚡ Bolt: stabilize task toggle callback in useTaskManagement

### DIFF
--- a/src/hooks/useTaskManagement.ts
+++ b/src/hooks/useTaskManagement.ts
@@ -202,11 +202,12 @@ export function useTaskManagement(ideaId: string): UseTaskManagementReturn {
         currentStatus === 'completed' ? 'todo' : 'completed';
 
       // Store previous state for potential rollback
-      previousDataRef.current = data;
+      // PERFORMANCE: Use dataRef.current to avoid dependency on data state
+      previousDataRef.current = dataRef.current;
 
       // Find the task for toast message BEFORE making changes
       const findTask = () => {
-        return data?.deliverables
+        return dataRef.current?.deliverables
           .flatMap((d) => d.tasks)
           .find((t) => t.id === taskId);
       };
@@ -293,7 +294,7 @@ export function useTaskManagement(ideaId: string): UseTaskManagementReturn {
         setUpdatingTaskId(null);
       }
     },
-    [data, logger, applyTaskStatusUpdate]
+    [logger, applyTaskStatusUpdate]
   );
 
   // Toggle deliverable expansion


### PR DESCRIPTION
### 💡 What:
Stabilized the `handleToggleTaskStatus` callback in the `useTaskManagement` hook.

### 🎯 Why:
Previously, `handleToggleTaskStatus` depended on the `data` state. Every time a task's status was toggled, the `data` state changed, causing the callback to be recreated. Since this callback is passed down to all `DeliverableCard` and `TaskItem` components, it triggered an O(N) re-render of the entire task management tree, even though these components are memoized.

### 📊 Impact:
- **Reduces re-renders:** Toggling a task now results in O(1) component re-evaluations for unrelated deliverables and tasks instead of O(N).
- **Smoother UI:** Improved responsiveness during optimistic updates in large projects.

### 🔬 Measurement:
Verified via code analysis and ensuring all existing tests pass with `pnpm check`. The use of `dataRef.current` is a standard pattern in this codebase for stabilizing callbacks that need access to the latest state.

---
*PR created automatically by Jules for task [14812373107066827595](https://jules.google.com/task/14812373107066827595) started by @cpa03*