### PR TITLE
🎨 Palette: Enhance ScrollToTop with tooltip and hover animation

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,5 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/components/ScrollToTop.tsx
+++ b/src/components/ScrollToTop.tsx
@@ -138,6 +138,7 @@ function ScrollToTopComponent({
           aria-live="polite"
           type="button"
         >
+          <span className="sr-only">Back to top</span>
       {!prefersReducedMotion && (
         <svg
           className="absolute inset-0 w-full h-full -rotate-90 pointer-events-none"
@@ -192,7 +193,6 @@ function ScrollToTopComponent({
         />
       </svg>
 
-          <span className="sr-only">Back to top</span>
         </button>
       </Tooltip>
     </div>

--- a/src/components/ScrollToTop.tsx
+++ b/src/components/ScrollToTop.tsx
@@ -9,6 +9,7 @@ import React, {
   memo,
 } from 'react';
 import { COMPONENT_DEFAULTS } from '@/lib/config';
+import Tooltip from './Tooltip';
 
 interface ScrollToTopProps {
   showAt?: number;
@@ -110,28 +111,33 @@ function ScrollToTopComponent({
     circumference - (scrollProgress / 100) * circumference;
 
   return (
-    <button
-      onClick={scrollToTop}
-      onKeyDown={handleKeyDown}
+    <div
       className={`
         fixed bottom-8 right-8 z-50
-        w-12 h-12
-        flex items-center justify-center
-        bg-white text-gray-700
-        rounded-full shadow-lg
-        border border-gray-200
-        transition-all duration-300 ease-out
-        hover:bg-gray-50 hover:text-primary-600 hover:shadow-xl hover:scale-110
-        hover:border-primary-200
-        focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2
-        active:scale-95
         ${prefersReducedMotion ? '' : 'animate-in fade-in slide-in-from-bottom-4 duration-300'}
         ${className}
       `}
-      aria-label={`Scroll to top of page (${Math.round(scrollProgress)}% scrolled)`}
-      aria-live="polite"
-      type="button"
     >
+      <Tooltip content="Back to top" position="top">
+        <button
+          onClick={scrollToTop}
+          onKeyDown={handleKeyDown}
+          className={`
+            group w-12 h-12
+            flex items-center justify-center
+            bg-white text-gray-700
+            rounded-full shadow-lg
+            border border-gray-200
+            transition-all duration-300 ease-out
+            hover:bg-gray-50 hover:text-primary-600 hover:shadow-xl hover:scale-110
+            hover:border-primary-200
+            focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2
+            active:scale-95
+          `}
+          aria-label={`Scroll to top of page (${Math.round(scrollProgress)}% scrolled)`}
+          aria-live="polite"
+          type="button"
+        >
       {!prefersReducedMotion && (
         <svg
           className="absolute inset-0 w-full h-full -rotate-90 pointer-events-none"
@@ -186,8 +192,10 @@ function ScrollToTopComponent({
         />
       </svg>
 
-      <span className="sr-only">Back to top</span>
-    </button>
+          <span className="sr-only">Back to top</span>
+        </button>
+      </Tooltip>
+    </div>
   );
 }
 

--- a/src/components/ScrollToTop.tsx
+++ b/src/components/ScrollToTop.tsx
@@ -9,7 +9,7 @@ import React, {
   memo,
 } from 'react';
 import { COMPONENT_DEFAULTS } from '@/lib/config';
-import Tooltip from './Tooltip';
+import Tooltip from '@/components/Tooltip';
 
 interface ScrollToTopProps {
   showAt?: number;

--- a/tests/ScrollToTop.test.tsx
+++ b/tests/ScrollToTop.test.tsx
@@ -97,12 +97,13 @@ describe('ScrollToTop', () => {
 
   it('should apply custom className to the wrapper', () => {
     Object.defineProperty(window, 'scrollY', { value: 500, writable: true });
-    const { container } = render(
-      <ScrollToTop showAt={400} className="custom-class" />
-    );
+    render(<ScrollToTop showAt={400} className="custom-class" />);
 
     fireEvent.scroll(window);
-    const wrapper = container.firstChild;
+    // Find the wrapper div using its class names or structure
+    const wrapper = screen.getByRole('button', {
+      name: /Scroll to top of page/,
+    }).closest('div.fixed');
 
     expect(wrapper).toHaveClass('custom-class');
   });

--- a/tests/ScrollToTop.test.tsx
+++ b/tests/ScrollToTop.test.tsx
@@ -95,14 +95,16 @@ describe('ScrollToTop', () => {
     expect(screen.getByText('Back to top')).toBeInTheDocument();
   });
 
-  it('should apply custom className', () => {
+  it('should apply custom className to the wrapper', () => {
     Object.defineProperty(window, 'scrollY', { value: 500, writable: true });
-    render(<ScrollToTop showAt={400} className="custom-class" />);
+    const { container } = render(
+      <ScrollToTop showAt={400} className="custom-class" />
+    );
 
     fireEvent.scroll(window);
-    const button = screen.getByLabelText(/Scroll to top of page/);
+    const wrapper = container.firstChild;
 
-    expect(button).toHaveClass('custom-class');
+    expect(wrapper).toHaveClass('custom-class');
   });
 
   it('should use default showAt value of 400', () => {


### PR DESCRIPTION
### 💡 What: The UX enhancement added
Enhanced the `ScrollToTop` component by adding a descriptive "Back to top" tooltip and fixing a broken hover animation.

### 🎯 Why: The user problem it solves
Icon-only buttons can be ambiguous for some users. Adding a tooltip provides immediate clarity on the button's function. Additionally, the component had a `group-hover` animation on the icon that wasn't triggering because the parent button was missing the `group` class.

### 📸 Before/After: Screenshots if visual change
The tooltip now appears on hover/focus, and the internal arrow icon subtly moves upward.

### ♿ Accessibility: Any a11y improvements made
- Added visual tooltip context for icon-only button.
- Maintained existing `aria-label` and `sr-only` text.
- Ensured tooltip works with keyboard focus.
- Improved focus management by moving `fixed` positioning to a wrapper, ensuring consistent placement during interactions.

---
*PR created automatically by Jules for task [16526097890000009141](https://jules.google.com/task/16526097890000009141) started by @cpa03*