### PR TITLE
🎨 Palette: Fix hover transitions in WhyChooseSection

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,5 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/components/WhyChooseSection.tsx
+++ b/src/components/WhyChooseSection.tsx
@@ -15,7 +15,7 @@ function WhyChooseSectionComponent() {
         Why Choose IdeaFlow for Project Planning?
       </h2>
       <div className="grid md:grid-cols-2 gap-6">
-        <article className="flex items-start space-x-3 p-4 rounded-lg bg-white border border-gray-100 shadow-sm hover:shadow-md hover:border-green-200 hover:bg-green-50/30 transition-all duration-200 ease-out motion-reduce:transition-none">
+        <article className="group flex items-start space-x-3 p-4 rounded-lg bg-white border border-gray-100 shadow-sm hover:shadow-md hover:border-green-200 hover:bg-green-50/30 transition-all duration-200 ease-out motion-reduce:transition-none">
           <div
             className="bg-green-100 rounded-full w-6 h-6 flex items-center justify-center flex-shrink-0 mt-1 group-hover:bg-green-200 transition-colors duration-200"
             aria-hidden="true"
@@ -42,7 +42,7 @@ function WhyChooseSectionComponent() {
             </p>
           </div>
         </article>
-        <article className="flex items-start space-x-3 p-4 rounded-lg bg-white border border-gray-100 shadow-sm hover:shadow-md hover:border-green-200 hover:bg-green-50/30 transition-all duration-200 ease-out motion-reduce:transition-none">
+        <article className="group flex items-start space-x-3 p-4 rounded-lg bg-white border border-gray-100 shadow-sm hover:shadow-md hover:border-green-200 hover:bg-green-50/30 transition-all duration-200 ease-out motion-reduce:transition-none">
           <div
             className="bg-green-100 rounded-full w-6 h-6 flex items-center justify-center flex-shrink-0 mt-1 group-hover:bg-green-200 transition-colors duration-200"
             aria-hidden="true"
@@ -69,7 +69,7 @@ function WhyChooseSectionComponent() {
             </p>
           </div>
         </article>
-        <article className="flex items-start space-x-3 p-4 rounded-lg bg-white border border-gray-100 shadow-sm hover:shadow-md hover:border-green-200 hover:bg-green-50/30 transition-all duration-200 ease-out motion-reduce:transition-none">
+        <article className="group flex items-start space-x-3 p-4 rounded-lg bg-white border border-gray-100 shadow-sm hover:shadow-md hover:border-green-200 hover:bg-green-50/30 transition-all duration-200 ease-out motion-reduce:transition-none">
           <div
             className="bg-green-100 rounded-full w-6 h-6 flex items-center justify-center flex-shrink-0 mt-1 group-hover:bg-green-200 transition-colors duration-200"
             aria-hidden="true"
@@ -96,7 +96,7 @@ function WhyChooseSectionComponent() {
             </p>
           </div>
         </article>
-        <article className="flex items-start space-x-3 p-4 rounded-lg bg-white border border-gray-100 shadow-sm hover:shadow-md hover:border-green-200 hover:bg-green-50/30 transition-all duration-200 ease-out motion-reduce:transition-none">
+        <article className="group flex items-start space-x-3 p-4 rounded-lg bg-white border border-gray-100 shadow-sm hover:shadow-md hover:border-green-200 hover:bg-green-50/30 transition-all duration-200 ease-out motion-reduce:transition-none">
           <div
             className="bg-green-100 rounded-full w-6 h-6 flex items-center justify-center flex-shrink-0 mt-1 group-hover:bg-green-200 transition-colors duration-200"
             aria-hidden="true"


### PR DESCRIPTION
Fixed a broken hover state in the `WhyChooseSection` component. The child elements (checkmark icons) were using `group-hover:bg-green-200` but didn't have a parent with the `group` class to trigger the effect.

Key changes:
- Added `group` class to `<article>` elements in `src/components/WhyChooseSection.tsx`.
- Reverted accidental framework-generated changes in `next-env.d.ts`.

Accessibility & UX:
- Improved visual feedback for mouse users when interacting with informational cards.
- Maintains compliance with "Palette" mission scope (< 50 lines, single improvement).

---
*PR created automatically by Jules for task [9904262916464614016](https://jules.google.com/task/9904262916464614016) started by @cpa03*