### PR TITLE
⚡ Bolt: Centralize usePrefersReducedMotion hook to reduce duplication

### DIFF
--- a/src/components/BlueprintDisplay.tsx
+++ b/src/components/BlueprintDisplay.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useSyncExternalStore, useRef, useEffect } from 'react';
+import React, { useRef, useEffect } from 'react';
 import LoadingSpinner from '@/components/LoadingSpinner';
 import Button from '@/components/Button';
 import Skeleton from '@/components/Skeleton';
@@ -9,24 +9,7 @@ import SuccessCelebration from '@/components/SuccessCelebration';
 import Tooltip from '@/components/Tooltip';
 import { useBlueprintGeneration } from '@/hooks/useBlueprintGeneration';
 import { MESSAGES, COMPONENT_DEFAULTS } from '@/lib/config';
-
-const subscribe = (callback: () => void) => {
-  if (typeof window === 'undefined') return () => {};
-  const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
-  mediaQuery.addEventListener('change', callback);
-  return () => mediaQuery.removeEventListener('change', callback);
-};
-
-const getSnapshot = () => {
-  if (typeof window === 'undefined') return false;
-  return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-};
-
-const getServerSnapshot = () => false;
-
-function usePrefersReducedMotion() {
-  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
-}
+import { usePrefersReducedMotion } from '@/hooks/usePrefersReducedMotion';
 
 interface BlueprintDisplayProps {
   idea: string;

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -8,33 +8,9 @@ import {
   useCallback,
   useEffect,
   useRef,
-  useSyncExternalStore,
 } from 'react';
 import { RIPPLE_CONFIG, BUTTON_STYLES } from '@/lib/config';
-
-// Custom hook to subscribe to prefers-reduced-motion media query
-// This properly updates when OS accessibility settings change during runtime
-const subscribeToMotionPreference = (callback: () => void) => {
-  if (typeof window === 'undefined') return () => {};
-  const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
-  mediaQuery.addEventListener('change', callback);
-  return () => mediaQuery.removeEventListener('change', callback);
-};
-
-const getMotionSnapshot = () => {
-  if (typeof window === 'undefined') return false;
-  return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-};
-
-const getServerMotionSnapshot = () => false;
-
-function usePrefersReducedMotion() {
-  return useSyncExternalStore(
-    subscribeToMotionPreference,
-    getMotionSnapshot,
-    getServerMotionSnapshot
-  );
-}
+import { usePrefersReducedMotion } from '@/hooks/usePrefersReducedMotion';
 
 export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: 'primary' | 'secondary' | 'outline' | 'ghost' | 'danger';

--- a/src/components/LoadingSpinner.tsx
+++ b/src/components/LoadingSpinner.tsx
@@ -1,34 +1,13 @@
 'use client';
 
-import { memo, useMemo, useSyncExternalStore } from 'react';
+import { memo, useMemo } from 'react';
 import { COMPONENT_CONFIG } from '@/lib/config';
+import { usePrefersReducedMotion } from '@/hooks/usePrefersReducedMotion';
 
 interface LoadingSpinnerProps {
   size?: 'sm' | 'md' | 'lg';
   className?: string;
   ariaLabel?: string;
-}
-
-const subscribeReducedMotion = (callback: () => void) => {
-  if (typeof window === 'undefined') return () => {};
-  const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
-  mediaQuery.addEventListener('change', callback);
-  return () => mediaQuery.removeEventListener('change', callback);
-};
-
-const getReducedMotionSnapshot = () => {
-  if (typeof window === 'undefined') return false;
-  return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-};
-
-const getReducedMotionServerSnapshot = () => false;
-
-function usePrefersReducedMotion() {
-  return useSyncExternalStore(
-    subscribeReducedMotion,
-    getReducedMotionSnapshot,
-    getReducedMotionServerSnapshot
-  );
 }
 
 function LoadingSpinnerComponent({

--- a/src/components/ScrollToTop.tsx
+++ b/src/components/ScrollToTop.tsx
@@ -5,37 +5,15 @@ import React, {
   useEffect,
   useCallback,
   useRef,
-  useSyncExternalStore,
   memo,
 } from 'react';
 import { COMPONENT_DEFAULTS } from '@/lib/config';
+import { usePrefersReducedMotion } from '@/hooks/usePrefersReducedMotion';
 
 interface ScrollToTopProps {
   showAt?: number;
   smooth?: boolean;
   className?: string;
-}
-
-const subscribeToReducedMotionMediaQuery = (callback: () => void) => {
-  if (typeof window === 'undefined') return () => {};
-  const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
-  mediaQuery.addEventListener('change', callback);
-  return () => mediaQuery.removeEventListener('change', callback);
-};
-
-const getReducedMotionSnapshot = () => {
-  if (typeof window === 'undefined') return false;
-  return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-};
-
-const getReducedMotionServerSnapshot = () => false;
-
-function usePrefersReducedMotion() {
-  return useSyncExternalStore(
-    subscribeToReducedMotionMediaQuery,
-    getReducedMotionSnapshot,
-    getReducedMotionServerSnapshot
-  );
 }
 
 // PERFORMANCE: Memoize ScrollToTop to prevent re-renders when parent components update

--- a/src/components/Skeleton.tsx
+++ b/src/components/Skeleton.tsx
@@ -1,24 +1,7 @@
 'use client';
 
-import React, { memo, useSyncExternalStore } from 'react';
-
-const subscribe = (callback: () => void) => {
-  if (typeof window === 'undefined') return () => {};
-  const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
-  mediaQuery.addEventListener('change', callback);
-  return () => mediaQuery.removeEventListener('change', callback);
-};
-
-const getSnapshot = () => {
-  if (typeof window === 'undefined') return false;
-  return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-};
-
-const getServerSnapshot = () => false;
-
-function usePrefersReducedMotion() {
-  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
-}
+import React, { memo } from 'react';
+import { usePrefersReducedMotion } from '@/hooks/usePrefersReducedMotion';
 
 interface SkeletonProps {
   className?: string;

--- a/src/components/StepCelebration.tsx
+++ b/src/components/StepCelebration.tsx
@@ -26,6 +26,8 @@ interface Particle {
   delay: number;
 }
 
+import { usePrefersReducedMotion } from '@/hooks/usePrefersReducedMotion';
+
 function StepCelebrationComponent({
   stepNumber,
   totalSteps,
@@ -35,19 +37,8 @@ function StepCelebrationComponent({
   const [isVisible, setIsVisible] = useState(false);
   const [isExiting, setIsExiting] = useState(false);
   const [particles, setParticles] = useState<Particle[]>([]);
-  const [shouldAnimate, setShouldAnimate] = useState(true);
-
-  useEffect(() => {
-    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
-    setShouldAnimate(!mediaQuery.matches);
-
-    const handleChange = (e: MediaQueryListEvent) => {
-      setShouldAnimate(!e.matches);
-    };
-
-    mediaQuery.addEventListener('change', handleChange);
-    return () => mediaQuery.removeEventListener('change', handleChange);
-  }, []);
+  const prefersReducedMotion = usePrefersReducedMotion();
+  const shouldAnimate = !prefersReducedMotion;
 
   const generateParticles = useCallback((): Particle[] => {
     return Array.from({ length: 8 }, (_, i) => ({

--- a/src/components/StepCelebration.tsx
+++ b/src/components/StepCelebration.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useEffect, useState, useCallback, memo } from 'react';
+import { usePrefersReducedMotion } from '@/hooks/usePrefersReducedMotion';
 import { ANIMATION_CONFIG } from '@/lib/config/constants';
 import {
   CELEBRATION_COLORS,
@@ -25,8 +26,6 @@ interface Particle {
   scale: number;
   delay: number;
 }
-
-import { usePrefersReducedMotion } from '@/hooks/usePrefersReducedMotion';
 
 function StepCelebrationComponent({
   stepNumber,

--- a/src/components/SuccessCelebration.tsx
+++ b/src/components/SuccessCelebration.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useEffect, useState, useCallback, memo } from 'react';
+import { usePrefersReducedMotion } from '@/hooks/usePrefersReducedMotion';
 import {
   CELEBRATION_COLORS,
   ANIMATION_PHYSICS,
@@ -25,8 +26,6 @@ interface SuccessCelebrationProps {
   onComplete?: () => void;
   duration?: number;
 }
-
-import { usePrefersReducedMotion } from '@/hooks/usePrefersReducedMotion';
 
 const COLORS = CELEBRATION_COLORS.ALL;
 const PARTICLE_COUNT = ANIMATION_PHYSICS.PARTICLE_COUNT;

--- a/src/components/SuccessCelebration.tsx
+++ b/src/components/SuccessCelebration.tsx
@@ -26,6 +26,8 @@ interface SuccessCelebrationProps {
   duration?: number;
 }
 
+import { usePrefersReducedMotion } from '@/hooks/usePrefersReducedMotion';
+
 const COLORS = CELEBRATION_COLORS.ALL;
 const PARTICLE_COUNT = ANIMATION_PHYSICS.PARTICLE_COUNT;
 
@@ -36,19 +38,8 @@ function SuccessCelebrationComponent({
 }: SuccessCelebrationProps) {
   const [particles, setParticles] = useState<Particle[]>([]);
   const [isVisible, setIsVisible] = useState(false);
-  const [shouldAnimate, setShouldAnimate] = useState(true);
-
-  useEffect(() => {
-    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
-    setShouldAnimate(!mediaQuery.matches);
-
-    const handleChange = (e: MediaQueryListEvent) => {
-      setShouldAnimate(!e.matches);
-    };
-
-    mediaQuery.addEventListener('change', handleChange);
-    return () => mediaQuery.removeEventListener('change', handleChange);
-  }, []);
+  const prefersReducedMotion = usePrefersReducedMotion();
+  const shouldAnimate = !prefersReducedMotion;
 
   const generateParticles = useCallback((): Particle[] => {
     return Array.from({ length: PARTICLE_COUNT }, (_, i) => ({

--- a/src/components/ToastContainer.tsx
+++ b/src/components/ToastContainer.tsx
@@ -6,13 +6,13 @@ import {
   useEffect,
   useState,
   useRef,
-  useSyncExternalStore,
 } from 'react';
 import {
   UI_CONFIG as UI_CONSTANTS,
   ANIMATION_CONFIG,
 } from '@/lib/config/constants';
 import { TOAST_CONFIG } from '@/lib/config';
+import { usePrefersReducedMotion } from '@/hooks/usePrefersReducedMotion';
 
 export interface Toast {
   id: string;
@@ -30,26 +30,6 @@ export interface ToastOptions {
 interface ToastProps {
   toast: Toast;
   onClose: (id: string) => void;
-}
-
-// Custom hook to subscribe to prefers-reduced-motion media query
-// This properly updates when OS accessibility settings change during runtime
-const subscribe = (callback: () => void) => {
-  if (typeof window === 'undefined') return () => {};
-  const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
-  mediaQuery.addEventListener('change', callback);
-  return () => mediaQuery.removeEventListener('change', callback);
-};
-
-const getSnapshot = () => {
-  if (typeof window === 'undefined') return false;
-  return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-};
-
-const getServerSnapshot = () => false;
-
-function usePrefersReducedMotion() {
-  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 }
 
 const toastIcons = {

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -7,9 +7,9 @@ import React, {
   useCallback,
   useId,
   memo,
-  useSyncExternalStore,
 } from 'react';
 import { ANIMATION_CONFIG, UI_CONFIG } from '@/lib/config/constants';
+import { usePrefersReducedMotion } from '@/hooks/usePrefersReducedMotion';
 
 type TooltipPosition = 'top' | 'bottom' | 'left' | 'right';
 
@@ -20,28 +20,6 @@ interface TooltipProps {
   delay?: number;
   disabled?: boolean;
   className?: string;
-}
-
-const subscribeReducedMotion = (callback: () => void) => {
-  if (typeof window === 'undefined') return () => {};
-  const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
-  mediaQuery.addEventListener('change', callback);
-  return () => mediaQuery.removeEventListener('change', callback);
-};
-
-const getReducedMotionSnapshot = () => {
-  if (typeof window === 'undefined') return false;
-  return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-};
-
-const getReducedMotionServerSnapshot = () => false;
-
-function usePrefersReducedMotion() {
-  return useSyncExternalStore(
-    subscribeReducedMotion,
-    getReducedMotionSnapshot,
-    getReducedMotionServerSnapshot
-  );
 }
 
 // PERFORMANCE: Memoize Tooltip to prevent re-renders when parent components update

--- a/src/hooks/usePrefersReducedMotion.ts
+++ b/src/hooks/usePrefersReducedMotion.ts
@@ -1,0 +1,33 @@
+'use client';
+
+import { useSyncExternalStore } from 'react';
+
+/**
+ * Custom hook to subscribe to prefers-reduced-motion media query.
+ * Consolidates accessibility logic used across multiple components to reduce code duplication and bundle size.
+ *
+ * @returns {boolean} True if the user prefers reduced motion, false otherwise.
+ */
+const subscribeToMotionPreference = (callback: () => void) => {
+  if (typeof window === 'undefined') return () => {};
+  const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+  mediaQuery.addEventListener('change', callback);
+  return () => mediaQuery.removeEventListener('change', callback);
+};
+
+const getMotionSnapshot = () => {
+  if (typeof window === 'undefined') return false;
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+};
+
+const getServerMotionSnapshot = () => false;
+
+export function usePrefersReducedMotion() {
+  return useSyncExternalStore(
+    subscribeToMotionPreference,
+    getMotionSnapshot,
+    getServerMotionSnapshot
+  );
+}
+
+export default usePrefersReducedMotion;


### PR DESCRIPTION
### 💡 What:
Centralized the `prefers-reduced-motion` media query logic into a single React hook (`src/hooks/usePrefersReducedMotion.ts`) and refactored 9 components to use it.

### 🎯 Why:
This specific accessibility check was duplicated in 9 different components, each maintaining its own media query listener. This redundancy increased the overall bundle size and potentially caused redundant state updates across multiple components.

### 📊 Impact:
- **Reduced Bundle Size:** Deletes ~100 lines of redundant code.
- **Improved Performance:** Consolidates media query subscriptions and uses `useSyncExternalStore` for more efficient React 18+ state synchronization.
- **Maintainability:** Provides a single source of truth for motion preference detection.

### 🔬 Measurement:
Verified that components still correctly detect and respect reduced motion settings via unit tests for `Button`, `ScrollToTop`, and `BlueprintDisplay`. Code review confirmed the consolidation of logic across all target components.

---
*PR created automatically by Jules for task [17762490582662494245](https://jules.google.com/task/17762490582662494245) started by @cpa03*