### PR TITLE
⚡ Bolt: Centralize motion preference hook and stabilize task callbacks

### DIFF
--- a/src/components/BlueprintDisplay.tsx
+++ b/src/components/BlueprintDisplay.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useSyncExternalStore, useRef, useEffect } from 'react';
+import React, { useRef, useEffect } from 'react';
 import LoadingSpinner from '@/components/LoadingSpinner';
 import Button from '@/components/Button';
 import Skeleton from '@/components/Skeleton';
@@ -9,24 +9,7 @@ import SuccessCelebration from '@/components/SuccessCelebration';
 import Tooltip from '@/components/Tooltip';
 import { useBlueprintGeneration } from '@/hooks/useBlueprintGeneration';
 import { MESSAGES, COMPONENT_DEFAULTS } from '@/lib/config';
-
-const subscribe = (callback: () => void) => {
-  if (typeof window === 'undefined') return () => {};
-  const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
-  mediaQuery.addEventListener('change', callback);
-  return () => mediaQuery.removeEventListener('change', callback);
-};
-
-const getSnapshot = () => {
-  if (typeof window === 'undefined') return false;
-  return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-};
-
-const getServerSnapshot = () => false;
-
-function usePrefersReducedMotion() {
-  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
-}
+import { usePrefersReducedMotion } from '@/hooks/usePrefersReducedMotion';
 
 interface BlueprintDisplayProps {
   idea: string;

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -8,33 +8,9 @@ import {
   useCallback,
   useEffect,
   useRef,
-  useSyncExternalStore,
 } from 'react';
 import { RIPPLE_CONFIG, BUTTON_STYLES } from '@/lib/config';
-
-// Custom hook to subscribe to prefers-reduced-motion media query
-// This properly updates when OS accessibility settings change during runtime
-const subscribeToMotionPreference = (callback: () => void) => {
-  if (typeof window === 'undefined') return () => {};
-  const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
-  mediaQuery.addEventListener('change', callback);
-  return () => mediaQuery.removeEventListener('change', callback);
-};
-
-const getMotionSnapshot = () => {
-  if (typeof window === 'undefined') return false;
-  return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-};
-
-const getServerMotionSnapshot = () => false;
-
-function usePrefersReducedMotion() {
-  return useSyncExternalStore(
-    subscribeToMotionPreference,
-    getMotionSnapshot,
-    getServerMotionSnapshot
-  );
-}
+import { usePrefersReducedMotion } from '@/hooks/usePrefersReducedMotion';
 
 export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: 'primary' | 'secondary' | 'outline' | 'ghost' | 'danger';

--- a/src/components/LoadingSpinner.tsx
+++ b/src/components/LoadingSpinner.tsx
@@ -1,34 +1,13 @@
 'use client';
 
-import { memo, useMemo, useSyncExternalStore } from 'react';
+import { memo, useMemo } from 'react';
 import { COMPONENT_CONFIG } from '@/lib/config';
+import { usePrefersReducedMotion } from '@/hooks/usePrefersReducedMotion';
 
 interface LoadingSpinnerProps {
   size?: 'sm' | 'md' | 'lg';
   className?: string;
   ariaLabel?: string;
-}
-
-const subscribeReducedMotion = (callback: () => void) => {
-  if (typeof window === 'undefined') return () => {};
-  const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
-  mediaQuery.addEventListener('change', callback);
-  return () => mediaQuery.removeEventListener('change', callback);
-};
-
-const getReducedMotionSnapshot = () => {
-  if (typeof window === 'undefined') return false;
-  return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-};
-
-const getReducedMotionServerSnapshot = () => false;
-
-function usePrefersReducedMotion() {
-  return useSyncExternalStore(
-    subscribeReducedMotion,
-    getReducedMotionSnapshot,
-    getReducedMotionServerSnapshot
-  );
 }
 
 function LoadingSpinnerComponent({

--- a/src/components/ScrollToTop.tsx
+++ b/src/components/ScrollToTop.tsx
@@ -5,37 +5,15 @@ import React, {
   useEffect,
   useCallback,
   useRef,
-  useSyncExternalStore,
   memo,
 } from 'react';
 import { COMPONENT_DEFAULTS } from '@/lib/config';
+import { usePrefersReducedMotion } from '@/hooks/usePrefersReducedMotion';
 
 interface ScrollToTopProps {
   showAt?: number;
   smooth?: boolean;
   className?: string;
-}
-
-const subscribeToReducedMotionMediaQuery = (callback: () => void) => {
-  if (typeof window === 'undefined') return () => {};
-  const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
-  mediaQuery.addEventListener('change', callback);
-  return () => mediaQuery.removeEventListener('change', callback);
-};
-
-const getReducedMotionSnapshot = () => {
-  if (typeof window === 'undefined') return false;
-  return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-};
-
-const getReducedMotionServerSnapshot = () => false;
-
-function usePrefersReducedMotion() {
-  return useSyncExternalStore(
-    subscribeToReducedMotionMediaQuery,
-    getReducedMotionSnapshot,
-    getReducedMotionServerSnapshot
-  );
 }
 
 // PERFORMANCE: Memoize ScrollToTop to prevent re-renders when parent components update

--- a/src/components/Skeleton.tsx
+++ b/src/components/Skeleton.tsx
@@ -1,24 +1,7 @@
 'use client';
 
-import React, { memo, useSyncExternalStore } from 'react';
-
-const subscribe = (callback: () => void) => {
-  if (typeof window === 'undefined') return () => {};
-  const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
-  mediaQuery.addEventListener('change', callback);
-  return () => mediaQuery.removeEventListener('change', callback);
-};
-
-const getSnapshot = () => {
-  if (typeof window === 'undefined') return false;
-  return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-};
-
-const getServerSnapshot = () => false;
-
-function usePrefersReducedMotion() {
-  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
-}
+import React, { memo } from 'react';
+import { usePrefersReducedMotion } from '@/hooks/usePrefersReducedMotion';
 
 interface SkeletonProps {
   className?: string;

--- a/src/components/ToastContainer.tsx
+++ b/src/components/ToastContainer.tsx
@@ -6,13 +6,13 @@ import {
   useEffect,
   useState,
   useRef,
-  useSyncExternalStore,
 } from 'react';
 import {
   UI_CONFIG as UI_CONSTANTS,
   ANIMATION_CONFIG,
 } from '@/lib/config/constants';
 import { TOAST_CONFIG } from '@/lib/config';
+import { usePrefersReducedMotion } from '@/hooks/usePrefersReducedMotion';
 
 export interface Toast {
   id: string;
@@ -30,26 +30,6 @@ export interface ToastOptions {
 interface ToastProps {
   toast: Toast;
   onClose: (id: string) => void;
-}
-
-// Custom hook to subscribe to prefers-reduced-motion media query
-// This properly updates when OS accessibility settings change during runtime
-const subscribe = (callback: () => void) => {
-  if (typeof window === 'undefined') return () => {};
-  const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
-  mediaQuery.addEventListener('change', callback);
-  return () => mediaQuery.removeEventListener('change', callback);
-};
-
-const getSnapshot = () => {
-  if (typeof window === 'undefined') return false;
-  return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-};
-
-const getServerSnapshot = () => false;
-
-function usePrefersReducedMotion() {
-  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 }
 
 const toastIcons = {

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -7,9 +7,9 @@ import React, {
   useCallback,
   useId,
   memo,
-  useSyncExternalStore,
 } from 'react';
 import { ANIMATION_CONFIG, UI_CONFIG } from '@/lib/config/constants';
+import { usePrefersReducedMotion } from '@/hooks/usePrefersReducedMotion';
 
 type TooltipPosition = 'top' | 'bottom' | 'left' | 'right';
 
@@ -20,28 +20,6 @@ interface TooltipProps {
   delay?: number;
   disabled?: boolean;
   className?: string;
-}
-
-const subscribeReducedMotion = (callback: () => void) => {
-  if (typeof window === 'undefined') return () => {};
-  const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
-  mediaQuery.addEventListener('change', callback);
-  return () => mediaQuery.removeEventListener('change', callback);
-};
-
-const getReducedMotionSnapshot = () => {
-  if (typeof window === 'undefined') return false;
-  return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-};
-
-const getReducedMotionServerSnapshot = () => false;
-
-function usePrefersReducedMotion() {
-  return useSyncExternalStore(
-    subscribeReducedMotion,
-    getReducedMotionSnapshot,
-    getReducedMotionServerSnapshot
-  );
 }
 
 // PERFORMANCE: Memoize Tooltip to prevent re-renders when parent components update

--- a/src/hooks/usePrefersReducedMotion.ts
+++ b/src/hooks/usePrefersReducedMotion.ts
@@ -1,0 +1,53 @@
+'use client';
+
+import { useSyncExternalStore } from 'react';
+
+/**
+ * Subscribes to the (prefers-reduced-motion: reduce) media query changes.
+ * Used with useSyncExternalStore for a robust, performant implementation
+ * that works correctly across SSR and client-side hydration.
+ */
+const subscribe = (callback: () => void) => {
+  if (typeof window === 'undefined') return () => {};
+
+  const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+
+  // Use modern addEventListener if available, fallback to addListener for older browsers
+  if (mediaQuery.addEventListener) {
+    mediaQuery.addEventListener('change', callback);
+    return () => mediaQuery.removeEventListener('change', callback);
+  } else {
+    // @ts-expect-error - Fallback for older browsers
+    mediaQuery.addListener(callback);
+    return () => {
+      // @ts-expect-error - Fallback for older browsers
+      mediaQuery.removeListener(callback);
+    };
+  }
+};
+
+/**
+ * Returns the current state of the prefers-reduced-motion media query.
+ */
+const getSnapshot = () => {
+  if (typeof window === 'undefined') return false;
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+};
+
+/**
+ * Returns the server-side snapshot (defaults to false/no reduced motion).
+ */
+const getServerSnapshot = () => false;
+
+/**
+ * A hook that returns true if the user has requested reduced motion at the OS level.
+ * Centralizing this logic improves performance by reducing redundant event listeners
+ * and ensures consistency across the application.
+ *
+ * @returns boolean indicating if reduced motion is preferred
+ */
+export function usePrefersReducedMotion() {
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}
+
+export default usePrefersReducedMotion;

--- a/src/hooks/usePrefersReducedMotion.ts
+++ b/src/hooks/usePrefersReducedMotion.ts
@@ -17,11 +17,9 @@ const subscribe = (callback: () => void) => {
     mediaQuery.addEventListener('change', callback);
     return () => mediaQuery.removeEventListener('change', callback);
   } else {
-    // @ts-expect-error - Fallback for older browsers
-    mediaQuery.addListener(callback);
+    (mediaQuery as MediaQueryList).addListener(callback);
     return () => {
-      // @ts-expect-error - Fallback for older browsers
-      mediaQuery.removeListener(callback);
+      (mediaQuery as MediaQueryList).removeListener(callback);
     };
   }
 };

--- a/src/hooks/useTaskManagement.ts
+++ b/src/hooks/useTaskManagement.ts
@@ -201,12 +201,16 @@ export function useTaskManagement(ideaId: string): UseTaskManagementReturn {
       const newStatus: TaskStatus =
         currentStatus === 'completed' ? 'todo' : 'completed';
 
+      // PERFORMANCE: Use dataRef.current instead of data from outer scope
+      // to keep this callback identity stable across re-renders.
+      const currentData = dataRef.current;
+
       // Store previous state for potential rollback
-      previousDataRef.current = data;
+      previousDataRef.current = currentData;
 
       // Find the task for toast message BEFORE making changes
       const findTask = () => {
-        return data?.deliverables
+        return currentData?.deliverables
           .flatMap((d) => d.tasks)
           .find((t) => t.id === taskId);
       };
@@ -293,7 +297,7 @@ export function useTaskManagement(ideaId: string): UseTaskManagementReturn {
         setUpdatingTaskId(null);
       }
     },
-    [data, logger, applyTaskStatusUpdate]
+    [logger, applyTaskStatusUpdate]
   );
 
   // Toggle deliverable expansion

--- a/tests/hooks/usePrefersReducedMotion.test.ts
+++ b/tests/hooks/usePrefersReducedMotion.test.ts
@@ -1,0 +1,43 @@
+import { renderHook } from '@testing-library/react';
+import { usePrefersReducedMotion } from '@/hooks/usePrefersReducedMotion';
+
+describe('usePrefersReducedMotion', () => {
+  const originalMatchMedia = window.matchMedia;
+
+  beforeEach(() => {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: jest.fn().mockImplementation(query => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: jest.fn(), // Deprecated
+        removeListener: jest.fn(), // Deprecated
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+      })),
+    });
+  });
+
+  afterEach(() => {
+    window.matchMedia = originalMatchMedia;
+  });
+
+  it('should return false by default (when matches is false)', () => {
+    const { result } = renderHook(() => usePrefersReducedMotion());
+    expect(result.current).toBe(false);
+  });
+
+  it('should return true when media query matches', () => {
+    (window.matchMedia as jest.Mock).mockImplementation(query => ({
+      matches: true,
+      media: query,
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    }));
+
+    const { result } = renderHook(() => usePrefersReducedMotion());
+    expect(result.current).toBe(true);
+  });
+});


### PR DESCRIPTION
### 💡 What:
1. Centralized the `usePrefersReducedMotion` hook logic from 7 different components into a single, robust hook in `src/hooks/usePrefersReducedMotion.ts` using `useSyncExternalStore`.
2. Optimized the `handleToggleTaskStatus` callback in `useTaskManagement.ts` by using the "ref-stabilized callback" pattern (tracking `data` via `useRef`).

### 🎯 Why:
- **Maintenance**: Logic duplication across 7 components (`Button`, `ScrollToTop`, `Tooltip`, etc.) is a maintenance burden. Centralizing it ensures consistent behavior and easier updates.
- **Performance**: In `useTaskManagement.ts`, the `handleToggleTaskStatus` callback previously depended on the entire `data` object. Every time a task was toggled (optimistic update), the callback identity changed, causing ALL task items to re-render (O(N)). By using a ref to track the latest data, the callback identity remains stable, preventing these unnecessary re-renders.

### 📊 Impact:
- **Reduces re-renders**: Toggling a task now only re-renders the affected task item instead of the entire list.
- **Reduces bundle size**: Removes duplicated code from 7 components.
- **Improved robustness**: `useSyncExternalStore` is the recommended React 18+ way to subscribe to external stores (like media queries) and handles SSR/hydration correctly.

### 🔬 Measurement:
- Verified via `pnpm lint` and `pnpm test:ci`.
- Interaction performance improvement can be observed in React DevTools by monitoring re-renders in the `TaskManagement` list when a task is toggled.

---
*PR created automatically by Jules for task [9118129008046358950](https://jules.google.com/task/9118129008046358950) started by @cpa03*