### PR TITLE
⚡ Bolt: stabilize handleToggleTaskStatus callback in useTaskManagement

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,5 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/hooks/useTaskManagement.ts
+++ b/src/hooks/useTaskManagement.ts
@@ -202,11 +202,11 @@ export function useTaskManagement(ideaId: string): UseTaskManagementReturn {
         currentStatus === 'completed' ? 'todo' : 'completed';
 
       // Store previous state for potential rollback
-      previousDataRef.current = data;
+      previousDataRef.current = dataRef.current;
 
       // Find the task for toast message BEFORE making changes
       const findTask = () => {
-        return data?.deliverables
+        return dataRef.current?.deliverables
           .flatMap((d) => d.tasks)
           .find((t) => t.id === taskId);
       };
@@ -293,7 +293,7 @@ export function useTaskManagement(ideaId: string): UseTaskManagementReturn {
         setUpdatingTaskId(null);
       }
     },
-    [data, logger, applyTaskStatusUpdate]
+    [logger, applyTaskStatusUpdate]
   );
 
   // Toggle deliverable expansion

--- a/tests/hooks/useTaskManagement.test.ts
+++ b/tests/hooks/useTaskManagement.test.ts
@@ -1,0 +1,101 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useTaskManagement } from '@/hooks/useTaskManagement';
+import { fetchWithTimeout } from '@/lib/api-client';
+
+jest.mock('@/lib/api-client', () => ({
+  fetchWithTimeout: jest.fn(),
+}));
+
+jest.mock('@/lib/logger', () => ({
+  createLogger: jest.fn(() => ({
+    info: jest.fn(),
+    error: jest.fn(),
+    errorWithContext: jest.fn(),
+  })),
+}));
+
+jest.mock('@/lib/utils', () => ({
+  triggerHapticFeedback: jest.fn(),
+}));
+
+describe('useTaskManagement', () => {
+  const mockIdeaId = 'test-idea-id';
+  const mockTasksResponse = {
+    success: true,
+    data: {
+      deliverables: [
+        {
+          id: 'd1',
+          title: 'Deliverable 1',
+          tasks: [
+            { id: 't1', title: 'Task 1', status: 'todo', estimate: 1 },
+            { id: 't2', title: 'Task 2', status: 'todo', estimate: 2 },
+          ],
+          progress: 0,
+          completedCount: 0,
+          totalCount: 2,
+          totalHours: 3,
+          completedHours: 0,
+        },
+      ],
+      summary: {
+        totalDeliverables: 1,
+        totalTasks: 2,
+        completedTasks: 0,
+        totalHours: 3,
+        completedHours: 0,
+        overallProgress: 0,
+      },
+    },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (fetchWithTimeout as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue(mockTasksResponse),
+    });
+  });
+
+  it('fetches tasks on mount', async () => {
+    const { result } = renderHook(() => useTaskManagement(mockIdeaId));
+
+    expect(result.current.loading).toBe(true);
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.data).toEqual({
+      ideaId: mockIdeaId,
+      deliverables: mockTasksResponse.data.deliverables,
+      summary: mockTasksResponse.data.summary,
+    });
+    expect(fetchWithTimeout).toHaveBeenCalledWith(`/api/ideas/${mockIdeaId}/tasks`);
+  });
+
+  it('handleToggleTaskStatus reference remains stable when data updates', async () => {
+    const { result } = renderHook(() => useTaskManagement(mockIdeaId));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    const firstCallback = result.current.handleToggleTaskStatus;
+
+    // Trigger a status toggle (optimistic update)
+    (fetchWithTimeout as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue({ success: true }),
+    });
+
+    await act(async () => {
+      await result.current.handleToggleTaskStatus('t1', 'todo');
+    });
+
+    const secondCallback = result.current.handleToggleTaskStatus;
+
+    // The callback should remain stable because it no longer depends on [data]
+    expect(firstCallback).toBe(secondCallback);
+  });
+});


### PR DESCRIPTION
I have optimized the `useTaskManagement` hook by stabilizing the `handleToggleTaskStatus` callback.

Previously, this callback depended on the `data` state, which meant it was recreated every time any task was updated. Since this callback is passed down to every `TaskItem` and `DeliverableCard`, its change triggered a re-render of the entire component tree, even for items that weren't affected by the change.

By using a `dataRef` (which was already partially implemented but not fully utilized for this purpose) to track the latest state, I was able to remove `data` from the callback's dependency array. This ensures the callback reference remains stable across updates.

I verified this change by:
1. Creating a new unit test `tests/hooks/useTaskManagement.test.ts` that specifically checks for callback stability.
2. Running the tests before and after the change (the test failed before and passed after).
3. Running existing component tests to ensure no regressions.
4. Documenting the learning in `.jules/bolt.md`.

---
*PR created automatically by Jules for task [7828891100404976898](https://jules.google.com/task/7828891100404976898) started by @cpa03*