### PR TITLE
⚡ Bolt: stabilize task toggle callback and memoize session tracker

### DIFF
--- a/src/components/SessionTracker.tsx
+++ b/src/components/SessionTracker.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { memo } from 'react';
 import { useSessionDuration } from '@/hooks/useSessionDuration';
 
 /**
@@ -12,11 +13,16 @@ import { useSessionDuration } from '@/hooks/useSessionDuration';
  * - Tab visibility changes
  *
  * This component is hidden and tracks silently in the background.
+ *
+ * PERFORMANCE: Wrapped in React.memo to prevent unnecessary re-execution of
+ * the useSessionDuration hook when its parent component re-renders.
  */
-export default function SessionTracker() {
+function SessionTracker() {
   // Initialize session tracking - no UI rendered
   useSessionDuration();
 
   // Return null - this is a tracking-only component with no visual presence
   return null;
 }
+
+export default memo(SessionTracker);

--- a/src/hooks/useTaskManagement.ts
+++ b/src/hooks/useTaskManagement.ts
@@ -44,6 +44,85 @@ interface UseTaskManagementReturn {
   collapseAll: () => void;
 }
 
+// PERFORMANCE: Move helper outside hook to prevent recreation on every render
+// This function is pure and only depends on its arguments.
+const applyTaskStatusUpdate = (
+  prevData: TasksResponse | null,
+  taskId: string,
+  newStatus: TaskStatus
+): TasksResponse | null => {
+  if (!prevData) return null;
+
+  const dIndex = prevData.deliverables.findIndex((d) =>
+    d.tasks.some((t) => t.id === taskId)
+  );
+  if (dIndex === -1) return prevData;
+
+  const deliverable = prevData.deliverables[dIndex];
+  const taskIndex = deliverable.tasks.findIndex((t) => t.id === taskId);
+  const task = deliverable.tasks[taskIndex];
+  const est = Number(task.estimate) || 0;
+
+  let deltaTasks = 0;
+  let deltaHours = 0;
+
+  if (newStatus === 'completed' && task.status !== 'completed') {
+    deltaTasks = 1;
+    deltaHours = est;
+  } else if (newStatus !== 'completed' && task.status === 'completed') {
+    deltaTasks = -1;
+    deltaHours = -est;
+  }
+
+  if (deltaTasks === 0) return prevData;
+
+  const updatedTasks = [...deliverable.tasks];
+  updatedTasks[taskIndex] = {
+    ...task,
+    status: newStatus,
+    completion_percentage: newStatus === 'completed' ? 100 : 0,
+  };
+
+  const newCompletedCount = deliverable.completedCount + deltaTasks;
+  const newCompletedHours =
+    Math.round((deliverable.completedHours + deltaHours) * 10) / 10;
+
+  const updatedDeliverable = {
+    ...deliverable,
+    tasks: updatedTasks,
+    completedCount: newCompletedCount,
+    completedHours: newCompletedHours,
+    progress: Math.round(
+      updatedTasks.length > 0
+        ? (newCompletedCount / updatedTasks.length) * 100
+        : 0
+    ),
+  };
+
+  const updatedDeliverables = [...prevData.deliverables];
+  updatedDeliverables[dIndex] = updatedDeliverable;
+
+  const { summary } = prevData;
+  const newOverallCompletedTasks = summary.completedTasks + deltaTasks;
+  const newOverallCompletedHours =
+    Math.round((summary.completedHours + deltaHours) * 10) / 10;
+
+  return {
+    ...prevData,
+    deliverables: updatedDeliverables,
+    summary: {
+      ...summary,
+      completedTasks: newOverallCompletedTasks,
+      completedHours: newOverallCompletedHours,
+      overallProgress: Math.round(
+        summary.totalTasks > 0
+          ? (newOverallCompletedTasks / summary.totalTasks) * 100
+          : 0
+      ),
+    },
+  };
+};
+
 export function useTaskManagement(ideaId: string): UseTaskManagementReturn {
   const logger = useMemo(() => createLogger('TaskManagement'), []);
   const [loading, setLoading] = useState(true);
@@ -60,6 +139,7 @@ export function useTaskManagement(ideaId: string): UseTaskManagementReturn {
   // PERFORMANCE: Use a ref to keep track of the latest data without triggering
   // re-creations of callbacks that depend on it.
   const dataRef = useRef(data);
+  // eslint-disable-next-line react-hooks/refs
   dataRef.current = data;
 
   // Fetch tasks on mount
@@ -114,87 +194,6 @@ export function useTaskManagement(ideaId: string): UseTaskManagementReturn {
     }
   }, [ideaId, logger]);
 
-  // Helper function to apply task status update to state
-  const applyTaskStatusUpdate = useCallback(
-    (
-      prevData: TasksResponse | null,
-      taskId: string,
-      newStatus: TaskStatus
-    ): TasksResponse | null => {
-      if (!prevData) return null;
-
-      const dIndex = prevData.deliverables.findIndex((d) =>
-        d.tasks.some((t) => t.id === taskId)
-      );
-      if (dIndex === -1) return prevData;
-
-      const deliverable = prevData.deliverables[dIndex];
-      const taskIndex = deliverable.tasks.findIndex((t) => t.id === taskId);
-      const task = deliverable.tasks[taskIndex];
-      const est = Number(task.estimate) || 0;
-
-      let deltaTasks = 0;
-      let deltaHours = 0;
-
-      if (newStatus === 'completed' && task.status !== 'completed') {
-        deltaTasks = 1;
-        deltaHours = est;
-      } else if (newStatus !== 'completed' && task.status === 'completed') {
-        deltaTasks = -1;
-        deltaHours = -est;
-      }
-
-      if (deltaTasks === 0) return prevData;
-
-      const updatedTasks = [...deliverable.tasks];
-      updatedTasks[taskIndex] = {
-        ...task,
-        status: newStatus,
-        completion_percentage: newStatus === 'completed' ? 100 : 0,
-      };
-
-      const newCompletedCount = deliverable.completedCount + deltaTasks;
-      const newCompletedHours =
-        Math.round((deliverable.completedHours + deltaHours) * 10) / 10;
-
-      const updatedDeliverable = {
-        ...deliverable,
-        tasks: updatedTasks,
-        completedCount: newCompletedCount,
-        completedHours: newCompletedHours,
-        progress: Math.round(
-          updatedTasks.length > 0
-            ? (newCompletedCount / updatedTasks.length) * 100
-            : 0
-        ),
-      };
-
-      const updatedDeliverables = [...prevData.deliverables];
-      updatedDeliverables[dIndex] = updatedDeliverable;
-
-      const { summary } = prevData;
-      const newOverallCompletedTasks = summary.completedTasks + deltaTasks;
-      const newOverallCompletedHours =
-        Math.round((summary.completedHours + deltaHours) * 10) / 10;
-
-      return {
-        ...prevData,
-        deliverables: updatedDeliverables,
-        summary: {
-          ...summary,
-          completedTasks: newOverallCompletedTasks,
-          completedHours: newOverallCompletedHours,
-          overallProgress: Math.round(
-            summary.totalTasks > 0
-              ? (newOverallCompletedTasks / summary.totalTasks) * 100
-              : 0
-          ),
-        },
-      };
-    },
-    []
-  );
-
   // Toggle task status with OPTIMISTIC updates
   const handleToggleTaskStatus = useCallback(
     async (taskId: string, currentStatus: TaskStatus) => {
@@ -202,11 +201,12 @@ export function useTaskManagement(ideaId: string): UseTaskManagementReturn {
         currentStatus === 'completed' ? 'todo' : 'completed';
 
       // Store previous state for potential rollback
-      previousDataRef.current = data;
+      // PERFORMANCE: Use dataRef.current to avoid dependency on 'data' state
+      previousDataRef.current = dataRef.current;
 
       // Find the task for toast message BEFORE making changes
       const findTask = () => {
-        return data?.deliverables
+        return dataRef.current?.deliverables
           .flatMap((d) => d.tasks)
           .find((t) => t.id === taskId);
       };
@@ -293,7 +293,7 @@ export function useTaskManagement(ideaId: string): UseTaskManagementReturn {
         setUpdatingTaskId(null);
       }
     },
-    [data, logger, applyTaskStatusUpdate]
+    [logger]
   );
 
   // Toggle deliverable expansion

--- a/src/hooks/useTaskManagement.ts
+++ b/src/hooks/useTaskManagement.ts
@@ -139,8 +139,10 @@ export function useTaskManagement(ideaId: string): UseTaskManagementReturn {
   // PERFORMANCE: Use a ref to keep track of the latest data without triggering
   // re-creations of callbacks that depend on it.
   const dataRef = useRef(data);
-  // eslint-disable-next-line react-hooks/refs
-  dataRef.current = data;
+
+  useEffect(() => {
+    dataRef.current = data;
+  }, [data]);
 
   // Fetch tasks on mount
   useEffect(() => {

--- a/src/lib/use-cache.ts
+++ b/src/lib/use-cache.ts
@@ -35,6 +35,7 @@ export function useCache<T>(
   // Use ref to avoid dependency on fetcher function identity
   // This prevents infinite re-renders when fetcher is not memoized by caller
   const fetcherRef = useRef(fetcher);
+  // eslint-disable-next-line react-hooks/refs
   fetcherRef.current = fetcher;
 
   const revalidate = useCallback(async () => {

--- a/src/lib/use-cache.ts
+++ b/src/lib/use-cache.ts
@@ -35,8 +35,10 @@ export function useCache<T>(
   // Use ref to avoid dependency on fetcher function identity
   // This prevents infinite re-renders when fetcher is not memoized by caller
   const fetcherRef = useRef(fetcher);
-  // eslint-disable-next-line react-hooks/refs
-  fetcherRef.current = fetcher;
+
+  useEffect(() => {
+    fetcherRef.current = fetcher;
+  }, [fetcher]);
 
   const revalidate = useCallback(async () => {
     try {


### PR DESCRIPTION
💡 What: This PR implements two performance optimizations: callback stabilization in the `useTaskManagement` hook and memoization of the `SessionTracker` component.

🎯 Why:
1. In `useTaskManagement`, the `handleToggleTaskStatus` callback previously depended on the entire `data` state. Every time a task status changed, the callback identity changed, causing all memoized `DeliverableCard` and `TaskItem` components to re-render (O(N) re-renders).
2. `SessionTracker` is a side-effect-only component that returns `null`. Without memoization, its internal `useSessionDuration` hook (which sets up event listeners) re-executes whenever its parent (like `KeyboardShortcutsProvider`) re-renders.

📊 Impact: 
- Toggling a task now results in O(1) component re-renders instead of O(N), as the `onToggleTask` prop remains stable.
- `SessionTracker` and its tracking logic are skipped during parent re-renders if no props change (it has none).

🔬 Measurement: 
- Verified with `pnpm test` and `pnpm lint`. 
- Structural changes confirmed via code review.
- Type-safety verified with `tsc --noEmit`.

---
*PR created automatically by Jules for task [15191415042696867211](https://jules.google.com/task/15191415042696867211) started by @cpa03*