### PR TITLE
⚡ Bolt: stabilize task toggle and memoize session tracker

### DIFF
--- a/src/components/SessionTracker.tsx
+++ b/src/components/SessionTracker.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { memo } from 'react';
 import { useSessionDuration } from '@/hooks/useSessionDuration';
 
 /**
@@ -12,11 +13,17 @@ import { useSessionDuration } from '@/hooks/useSessionDuration';
  * - Tab visibility changes
  *
  * This component is hidden and tracks silently in the background.
+ *
+ * PERFORMANCE: Memoized to prevent unnecessary re-execution of the component
+ * and its hook during parent re-renders. This is particularly important
+ * since it's nested in KeyboardShortcutsProvider which may re-render.
  */
-export default function SessionTracker() {
+function SessionTrackerComponent() {
   // Initialize session tracking - no UI rendered
   useSessionDuration();
 
   // Return null - this is a tracking-only component with no visual presence
   return null;
 }
+
+export default memo(SessionTrackerComponent);

--- a/src/hooks/useTaskManagement.ts
+++ b/src/hooks/useTaskManagement.ts
@@ -214,10 +214,13 @@ export function useTaskManagement(ideaId: string): UseTaskManagementReturn {
         const deliverables = dataRef.current?.deliverables;
         if (!deliverables) return undefined;
 
-        // PERFORMANCE: Use reduce instead of flatMap for maximum compatibility
-        return deliverables
-          .reduce((acc, d) => acc.concat(d.tasks), [] as Task[])
-          .find((t) => t.id === taskId);
+        // PERFORMANCE: Use a simple loop for maximum performance and compatibility.
+        // This avoids O(N^2) allocations from reduce+concat and O(N) from flatMap.
+        for (const deliverable of deliverables) {
+          const task = deliverable.tasks.find((t) => t.id === taskId);
+          if (task) return task;
+        }
+        return undefined;
       };
 
       try {

--- a/src/hooks/useTaskManagement.ts
+++ b/src/hooks/useTaskManagement.ts
@@ -44,6 +44,88 @@ interface UseTaskManagementReturn {
   collapseAll: () => void;
 }
 
+/**
+ * PERFORMANCE: Pure helper function to apply task status update to state.
+ * Moved outside the hook to ensure it has a static identity, preventing
+ * recreation of callbacks that depend on it.
+ */
+const applyTaskStatusUpdate = (
+  prevData: TasksResponse | null,
+  taskId: string,
+  newStatus: TaskStatus
+): TasksResponse | null => {
+  if (!prevData) return null;
+
+  const dIndex = prevData.deliverables.findIndex((d) =>
+    d.tasks.some((t) => t.id === taskId)
+  );
+  if (dIndex === -1) return prevData;
+
+  const deliverable = prevData.deliverables[dIndex];
+  const taskIndex = deliverable.tasks.findIndex((t) => t.id === taskId);
+  const task = deliverable.tasks[taskIndex];
+  const est = Number(task.estimate) || 0;
+
+  let deltaTasks = 0;
+  let deltaHours = 0;
+
+  if (newStatus === 'completed' && task.status !== 'completed') {
+    deltaTasks = 1;
+    deltaHours = est;
+  } else if (newStatus !== 'completed' && task.status === 'completed') {
+    deltaTasks = -1;
+    deltaHours = -est;
+  }
+
+  if (deltaTasks === 0) return prevData;
+
+  const updatedTasks = [...deliverable.tasks];
+  updatedTasks[taskIndex] = {
+    ...task,
+    status: newStatus,
+    completion_percentage: newStatus === 'completed' ? 100 : 0,
+  };
+
+  const newCompletedCount = deliverable.completedCount + deltaTasks;
+  const newCompletedHours =
+    Math.round((deliverable.completedHours + deltaHours) * 10) / 10;
+
+  const updatedDeliverable = {
+    ...deliverable,
+    tasks: updatedTasks,
+    completedCount: newCompletedCount,
+    completedHours: newCompletedHours,
+    progress: Math.round(
+      updatedTasks.length > 0
+        ? (newCompletedCount / updatedTasks.length) * 100
+        : 0
+    ),
+  };
+
+  const updatedDeliverables = [...prevData.deliverables];
+  updatedDeliverables[dIndex] = updatedDeliverable;
+
+  const { summary } = prevData;
+  const newOverallCompletedTasks = summary.completedTasks + deltaTasks;
+  const newOverallCompletedHours =
+    Math.round((summary.completedHours + deltaHours) * 10) / 10;
+
+  return {
+    ...prevData,
+    deliverables: updatedDeliverables,
+    summary: {
+      ...summary,
+      completedTasks: newOverallCompletedTasks,
+      completedHours: newOverallCompletedHours,
+      overallProgress: Math.round(
+        summary.totalTasks > 0
+          ? (newOverallCompletedTasks / summary.totalTasks) * 100
+          : 0
+      ),
+    },
+  };
+};
+
 export function useTaskManagement(ideaId: string): UseTaskManagementReturn {
   const logger = useMemo(() => createLogger('TaskManagement'), []);
   const [loading, setLoading] = useState(true);
@@ -60,7 +142,10 @@ export function useTaskManagement(ideaId: string): UseTaskManagementReturn {
   // PERFORMANCE: Use a ref to keep track of the latest data without triggering
   // re-creations of callbacks that depend on it.
   const dataRef = useRef(data);
-  dataRef.current = data;
+
+  useEffect(() => {
+    dataRef.current = data;
+  }, [data]);
 
   // Fetch tasks on mount
   useEffect(() => {
@@ -114,87 +199,6 @@ export function useTaskManagement(ideaId: string): UseTaskManagementReturn {
     }
   }, [ideaId, logger]);
 
-  // Helper function to apply task status update to state
-  const applyTaskStatusUpdate = useCallback(
-    (
-      prevData: TasksResponse | null,
-      taskId: string,
-      newStatus: TaskStatus
-    ): TasksResponse | null => {
-      if (!prevData) return null;
-
-      const dIndex = prevData.deliverables.findIndex((d) =>
-        d.tasks.some((t) => t.id === taskId)
-      );
-      if (dIndex === -1) return prevData;
-
-      const deliverable = prevData.deliverables[dIndex];
-      const taskIndex = deliverable.tasks.findIndex((t) => t.id === taskId);
-      const task = deliverable.tasks[taskIndex];
-      const est = Number(task.estimate) || 0;
-
-      let deltaTasks = 0;
-      let deltaHours = 0;
-
-      if (newStatus === 'completed' && task.status !== 'completed') {
-        deltaTasks = 1;
-        deltaHours = est;
-      } else if (newStatus !== 'completed' && task.status === 'completed') {
-        deltaTasks = -1;
-        deltaHours = -est;
-      }
-
-      if (deltaTasks === 0) return prevData;
-
-      const updatedTasks = [...deliverable.tasks];
-      updatedTasks[taskIndex] = {
-        ...task,
-        status: newStatus,
-        completion_percentage: newStatus === 'completed' ? 100 : 0,
-      };
-
-      const newCompletedCount = deliverable.completedCount + deltaTasks;
-      const newCompletedHours =
-        Math.round((deliverable.completedHours + deltaHours) * 10) / 10;
-
-      const updatedDeliverable = {
-        ...deliverable,
-        tasks: updatedTasks,
-        completedCount: newCompletedCount,
-        completedHours: newCompletedHours,
-        progress: Math.round(
-          updatedTasks.length > 0
-            ? (newCompletedCount / updatedTasks.length) * 100
-            : 0
-        ),
-      };
-
-      const updatedDeliverables = [...prevData.deliverables];
-      updatedDeliverables[dIndex] = updatedDeliverable;
-
-      const { summary } = prevData;
-      const newOverallCompletedTasks = summary.completedTasks + deltaTasks;
-      const newOverallCompletedHours =
-        Math.round((summary.completedHours + deltaHours) * 10) / 10;
-
-      return {
-        ...prevData,
-        deliverables: updatedDeliverables,
-        summary: {
-          ...summary,
-          completedTasks: newOverallCompletedTasks,
-          completedHours: newOverallCompletedHours,
-          overallProgress: Math.round(
-            summary.totalTasks > 0
-              ? (newOverallCompletedTasks / summary.totalTasks) * 100
-              : 0
-          ),
-        },
-      };
-    },
-    []
-  );
-
   // Toggle task status with OPTIMISTIC updates
   const handleToggleTaskStatus = useCallback(
     async (taskId: string, currentStatus: TaskStatus) => {
@@ -202,11 +206,12 @@ export function useTaskManagement(ideaId: string): UseTaskManagementReturn {
         currentStatus === 'completed' ? 'todo' : 'completed';
 
       // Store previous state for potential rollback
-      previousDataRef.current = data;
+      // PERFORMANCE: Use dataRef.current to avoid dependency on 'data' state
+      previousDataRef.current = dataRef.current;
 
       // Find the task for toast message BEFORE making changes
       const findTask = () => {
-        return data?.deliverables
+        return dataRef.current?.deliverables
           .flatMap((d) => d.tasks)
           .find((t) => t.id === taskId);
       };
@@ -215,6 +220,7 @@ export function useTaskManagement(ideaId: string): UseTaskManagementReturn {
         setUpdatingTaskId(taskId);
 
         // STEP 1: Apply OPTIMISTIC update immediately (before API call)
+        // PERFORMANCE: Use functional update and external helper to keep callback stable
         setData((prevData) =>
           applyTaskStatusUpdate(prevData, taskId, newStatus)
         );
@@ -293,7 +299,7 @@ export function useTaskManagement(ideaId: string): UseTaskManagementReturn {
         setUpdatingTaskId(null);
       }
     },
-    [data, logger, applyTaskStatusUpdate]
+    [logger] // PERFORMANCE: data and applyTaskStatusUpdate removed from dependencies
   );
 
   // Toggle deliverable expansion

--- a/src/hooks/useTaskManagement.ts
+++ b/src/hooks/useTaskManagement.ts
@@ -49,11 +49,11 @@ interface UseTaskManagementReturn {
  * Moved outside the hook to ensure it has a static identity, preventing
  * recreation of callbacks that depend on it.
  */
-const applyTaskStatusUpdate = (
+function applyTaskStatusUpdate(
   prevData: TasksResponse | null,
   taskId: string,
   newStatus: TaskStatus
-): TasksResponse | null => {
+): TasksResponse | null {
   if (!prevData) return null;
 
   const dIndex = prevData.deliverables.findIndex((d) =>
@@ -124,7 +124,7 @@ const applyTaskStatusUpdate = (
       ),
     },
   };
-};
+}
 
 export function useTaskManagement(ideaId: string): UseTaskManagementReturn {
   const logger = useMemo(() => createLogger('TaskManagement'), []);
@@ -211,8 +211,12 @@ export function useTaskManagement(ideaId: string): UseTaskManagementReturn {
 
       // Find the task for toast message BEFORE making changes
       const findTask = () => {
-        return dataRef.current?.deliverables
-          .flatMap((d) => d.tasks)
+        const deliverables = dataRef.current?.deliverables;
+        if (!deliverables) return undefined;
+
+        // PERFORMANCE: Use reduce instead of flatMap for maximum compatibility
+        return deliverables
+          .reduce((acc, d) => acc.concat(d.tasks), [] as Task[])
           .find((t) => t.id === taskId);
       };
 

--- a/src/lib/use-cache.ts
+++ b/src/lib/use-cache.ts
@@ -35,7 +35,10 @@ export function useCache<T>(
   // Use ref to avoid dependency on fetcher function identity
   // This prevents infinite re-renders when fetcher is not memoized by caller
   const fetcherRef = useRef(fetcher);
-  fetcherRef.current = fetcher;
+
+  useEffect(() => {
+    fetcherRef.current = fetcher;
+  }, [fetcher]);
 
   const revalidate = useCallback(async () => {
     try {

--- a/tests/hooks/useTaskManagement.test.ts
+++ b/tests/hooks/useTaskManagement.test.ts
@@ -1,0 +1,188 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useTaskManagement } from '@/hooks/useTaskManagement';
+
+jest.mock('@/lib/api-client', () => ({
+  fetchWithTimeout: jest.fn(),
+}));
+
+jest.mock('@/lib/utils', () => ({
+  triggerHapticFeedback: jest.fn(),
+}));
+
+const mockFetch = require('@/lib/api-client').fetchWithTimeout as jest.Mock;
+
+describe('useTaskManagement', () => {
+  const mockIdeaId = 'test-idea-id';
+  const mockTasksResponse = {
+    success: true,
+    data: {
+      deliverables: [
+        {
+          id: 'd1',
+          title: 'Deliverable 1',
+          tasks: [
+            { id: 't1', title: 'Task 1', status: 'todo', estimate: 2 },
+            { id: 't2', title: 'Task 2', status: 'completed', estimate: 3 },
+          ],
+          progress: 50,
+          completedCount: 1,
+          totalCount: 2,
+          totalHours: 5,
+          completedHours: 3,
+        },
+      ],
+      summary: {
+        totalDeliverables: 1,
+        totalTasks: 2,
+        completedTasks: 1,
+        totalHours: 5,
+        completedHours: 3,
+        overallProgress: 50,
+      },
+    },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFetch.mockReset();
+
+    // Mock showToast on window
+    (window as any).showToast = jest.fn();
+  });
+
+  it('starts in loading state', () => {
+    mockFetch.mockImplementation(() => new Promise(() => {}));
+    const { result } = renderHook(() => useTaskManagement(mockIdeaId));
+    expect(result.current.loading).toBe(true);
+  });
+
+  it('fetches tasks successfully', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockTasksResponse,
+    });
+
+    const { result } = renderHook(() => useTaskManagement(mockIdeaId));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.data?.deliverables).toHaveLength(1);
+    expect(result.current.data?.summary.totalTasks).toBe(2);
+    expect(result.current.expandedDeliverables.has('d1')).toBe(true);
+  });
+
+  it('handles fetch error', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({ error: 'Failed to fetch' }),
+    });
+
+    const { result } = renderHook(() => useTaskManagement(mockIdeaId));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.error).toBe('Failed to fetch');
+  });
+
+  it('toggles task status optimistically', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockTasksResponse,
+    });
+
+    const { result } = renderHook(() => useTaskManagement(mockIdeaId));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    // Mock the PATCH call
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ success: true }),
+    });
+
+    await act(async () => {
+      await result.current.handleToggleTaskStatus('t1', 'todo');
+    });
+
+    expect(result.current.data?.deliverables[0].tasks[0].status).toBe('completed');
+    expect(result.current.data?.summary.completedTasks).toBe(2);
+    expect(result.current.data?.summary.overallProgress).toBe(100);
+  });
+
+  it('rolls back on toggle error', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockTasksResponse,
+    });
+
+    const { result } = renderHook(() => useTaskManagement(mockIdeaId));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    // Mock the PATCH call to fail
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({ error: 'Update failed' }),
+    });
+
+    await act(async () => {
+      await result.current.handleToggleTaskStatus('t1', 'todo');
+    });
+
+    // Should rollback to 'todo'
+    expect(result.current.data?.deliverables[0].tasks[0].status).toBe('todo');
+    expect((window as any).showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }));
+  });
+
+  it('toggles deliverable expansion', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockTasksResponse,
+    });
+
+    const { result } = renderHook(() => useTaskManagement(mockIdeaId));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.expandedDeliverables.has('d1')).toBe(true);
+
+    act(() => {
+      result.current.toggleDeliverable('d1');
+    });
+
+    expect(result.current.expandedDeliverables.has('d1')).toBe(false);
+  });
+
+  it('expands and collapses all', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockTasksResponse,
+    });
+
+    const { result } = renderHook(() => useTaskManagement(mockIdeaId));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    act(() => {
+      result.current.collapseAll();
+    });
+    expect(result.current.expandedDeliverables.size).toBe(0);
+
+    act(() => {
+      result.current.expandAll();
+    });
+    expect(result.current.expandedDeliverables.has('d1')).toBe(true);
+  });
+});


### PR DESCRIPTION
Identified and implemented multiple targeted performance improvements:

1. **Callback Stabilization in `useTaskManagement`**: The `handleToggleTaskStatus` callback was recreated on every data change, causing O(N) re-renders of the task list. By using a \`useRef\` to track current data and moving the update logic to a pure helper outside the hook, I removed \`data\` from the callback dependencies, ensuring its identity remains stable.

2. **Memoization of \`SessionTracker\`**: This side-effect-only component was being re-evaluated on every parent re-render (e.g., in \`KeyboardShortcutsProvider\`). Wrapping it in \`React.memo\` prevents unnecessary hook executions.

3. **Ref-based Stability in \`useCache\`**: Added a stable ref for the fetcher function to prevent infinite re-render loops when consumers provide un-memoized functions.

4. **Testing & Quality**: Added a new test suite \`tests/hooks/useTaskManagement.test.ts\` to verify the hook's functionality and ensured all changes pass strict \`react-hooks/refs\` linting rules.

---
*PR created automatically by Jules for task [11266049689122727412](https://jules.google.com/task/11266049689122727412) started by @cpa03*