### PR TITLE
🎨 Palette: Add tooltip and fix hover animation in ScrollToTop

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -12,3 +12,7 @@
 ## 2026-02-25 - [Tooltip for Icon-Only Clear Button]
 **Learning:** Adding a tooltip to icon-only buttons (like a "Clear" button in an input field) provides essential context for users before they interact with it. To prevent the `Tooltip` component's `relative inline-flex` styles from disrupting the `absolute` positioning of elements within an input container, the `Tooltip` should be wrapped in an `absolute` positioned `div` that mirrors the original element's placement.
 **Action:** Always wrap `Tooltip` in an `absolute` positioned container when used for elements that require precise absolute placement within a parent.
+
+## 2026-04-22 - [Tooltip and Animation for ScrollToTop]
+**Learning:** Adding a 'group' class to a parent interactive element is necessary to trigger CSS transitions (like 'group-hover') on its children. When wrapping a fixed-position button with a Tooltip, the 'fixed' positioning should be moved to the outermost container to ensure the Tooltip's relative positioning logic remains stable and doesn't conflict with the button's layout.
+**Action:** Always use the 'group' class on parents for child hover effects and ensure 'fixed' positioning is handled by the wrapper when using Tooltips.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/components/ScrollToTop.tsx
+++ b/src/components/ScrollToTop.tsx
@@ -9,6 +9,7 @@ import React, {
   memo,
 } from 'react';
 import { COMPONENT_DEFAULTS } from '@/lib/config';
+import Tooltip from './Tooltip';
 
 interface ScrollToTopProps {
   showAt?: number;
@@ -110,29 +111,35 @@ function ScrollToTopComponent({
     circumference - (scrollProgress / 100) * circumference;
 
   return (
-    <button
-      onClick={scrollToTop}
-      onKeyDown={handleKeyDown}
+    <div
       className={`
         fixed bottom-8 right-8 z-50
-        w-12 h-12
-        flex items-center justify-center
-        bg-white text-gray-700
-        rounded-full shadow-lg
-        border border-gray-200
-        transition-all duration-300 ease-out
-        hover:bg-gray-50 hover:text-primary-600 hover:shadow-xl hover:scale-110
-        hover:border-primary-200
-        focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2
-        active:scale-95
         ${prefersReducedMotion ? '' : 'animate-in fade-in slide-in-from-bottom-4 duration-300'}
         ${className}
       `}
-      aria-label={`Scroll to top of page (${Math.round(scrollProgress)}% scrolled)`}
-      aria-live="polite"
-      type="button"
     >
-      {!prefersReducedMotion && (
+      <Tooltip content="Back to top" position="top">
+        <button
+          onClick={scrollToTop}
+          onKeyDown={handleKeyDown}
+          className={`
+            group
+            w-12 h-12
+            flex items-center justify-center
+            bg-white text-gray-700
+            rounded-full shadow-lg
+            border border-gray-200
+            transition-all duration-300 ease-out
+            hover:bg-gray-50 hover:text-primary-600 hover:shadow-xl hover:scale-110
+            hover:border-primary-200
+            focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2
+            active:scale-95
+          `}
+          aria-label={`Scroll to top of page (${Math.round(scrollProgress)}% scrolled)`}
+          aria-live="polite"
+          type="button"
+        >
+          {!prefersReducedMotion && (
         <svg
           className="absolute inset-0 w-full h-full -rotate-90 pointer-events-none"
           viewBox="0 0 48 48"
@@ -187,7 +194,9 @@ function ScrollToTopComponent({
       </svg>
 
       <span className="sr-only">Back to top</span>
-    </button>
+        </button>
+      </Tooltip>
+    </div>
   );
 }
 

--- a/src/hooks/useTaskManagement.ts
+++ b/src/hooks/useTaskManagement.ts
@@ -60,8 +60,7 @@ export function useTaskManagement(ideaId: string): UseTaskManagementReturn {
   // PERFORMANCE: Use a ref to keep track of the latest data without triggering
   // re-creations of callbacks that depend on it.
   const dataRef = useRef(data);
-  // eslint-disable-next-line react-hooks/refs
-  dataRef.current = data;
+  useEffect(() => { dataRef.current = data; }, [data]);
 
   // Fetch tasks on mount
   useEffect(() => {

--- a/src/hooks/useTaskManagement.ts
+++ b/src/hooks/useTaskManagement.ts
@@ -60,11 +60,8 @@ export function useTaskManagement(ideaId: string): UseTaskManagementReturn {
   // PERFORMANCE: Use a ref to keep track of the latest data without triggering
   // re-creations of callbacks that depend on it.
   const dataRef = useRef(data);
-
-  // Update dataRef in an effect to avoid lint errors and potential hydration issues
-  useEffect(() => {
-    dataRef.current = data;
-  }, [data]);
+  // eslint-disable-next-line react-hooks/refs
+  dataRef.current = data;
 
   // Fetch tasks on mount
   useEffect(() => {

--- a/src/hooks/useTaskManagement.ts
+++ b/src/hooks/useTaskManagement.ts
@@ -60,7 +60,11 @@ export function useTaskManagement(ideaId: string): UseTaskManagementReturn {
   // PERFORMANCE: Use a ref to keep track of the latest data without triggering
   // re-creations of callbacks that depend on it.
   const dataRef = useRef(data);
-  dataRef.current = data;
+
+  // Update dataRef in an effect to avoid lint errors and potential hydration issues
+  useEffect(() => {
+    dataRef.current = data;
+  }, [data]);
 
   // Fetch tasks on mount
   useEffect(() => {

--- a/src/lib/config/constants.ts
+++ b/src/lib/config/constants.ts
@@ -345,13 +345,6 @@ export const AI_CONFIG = {
 
   /**
    * Default pricing fallback
-    'gpt-3.5-turbo': 0.000002,
-    'gpt-4': 0.00003,
-    'gpt-4-turbo': 0.00001,
-  } as const,
-
-  /**
-   * Default pricing fallback
    * NOTE: Not environment-configurable
    */
   DEFAULT_PRICING_PER_TOKEN: 0.00001,

--- a/src/lib/use-cache.ts
+++ b/src/lib/use-cache.ts
@@ -35,11 +35,8 @@ export function useCache<T>(
   // Use ref to avoid dependency on fetcher function identity
   // This prevents infinite re-renders when fetcher is not memoized by caller
   const fetcherRef = useRef(fetcher);
-
-  // Update fetcherRef in an effect to avoid lint errors and potential hydration issues
-  useEffect(() => {
-    fetcherRef.current = fetcher;
-  }, [fetcher]);
+  // eslint-disable-next-line react-hooks/refs
+  fetcherRef.current = fetcher;
 
   const revalidate = useCallback(async () => {
     try {

--- a/src/lib/use-cache.ts
+++ b/src/lib/use-cache.ts
@@ -35,7 +35,11 @@ export function useCache<T>(
   // Use ref to avoid dependency on fetcher function identity
   // This prevents infinite re-renders when fetcher is not memoized by caller
   const fetcherRef = useRef(fetcher);
-  fetcherRef.current = fetcher;
+
+  // Update fetcherRef in an effect to avoid lint errors and potential hydration issues
+  useEffect(() => {
+    fetcherRef.current = fetcher;
+  }, [fetcher]);
 
   const revalidate = useCallback(async () => {
     try {

--- a/src/lib/use-cache.ts
+++ b/src/lib/use-cache.ts
@@ -35,8 +35,7 @@ export function useCache<T>(
   // Use ref to avoid dependency on fetcher function identity
   // This prevents infinite re-renders when fetcher is not memoized by caller
   const fetcherRef = useRef(fetcher);
-  // eslint-disable-next-line react-hooks/refs
-  fetcherRef.current = fetcher;
+  useEffect(() => { fetcherRef.current = fetcher; }, [fetcher]);
 
   const revalidate = useCallback(async () => {
     try {

--- a/tests/ScrollToTop.test.tsx
+++ b/tests/ScrollToTop.test.tsx
@@ -95,14 +95,16 @@ describe('ScrollToTop', () => {
     expect(screen.getByText('Back to top')).toBeInTheDocument();
   });
 
-  it('should apply custom className', () => {
+  it('should apply custom className to the container', () => {
     Object.defineProperty(window, 'scrollY', { value: 500, writable: true });
-    render(<ScrollToTop showAt={400} className="custom-class" />);
+    const { container } = render(
+      <ScrollToTop showAt={400} className="custom-class" />
+    );
 
     fireEvent.scroll(window);
-    const button = screen.getByLabelText(/Scroll to top of page/);
+    const wrapper = container.querySelector('.fixed');
 
-    expect(button).toHaveClass('custom-class');
+    expect(wrapper).toHaveClass('custom-class');
   });
 
   it('should use default showAt value of 400', () => {


### PR DESCRIPTION
This PR introduces a micro-UX improvement to the `ScrollToTop` component by adding a "Back to top" tooltip and fixing a missing Tailwind `group` class that prevented the hover animation from triggering.

### 💡 What:
- Added a `Tooltip` wrapper around the `ScrollToTop` button.
- Added the `group` class to the button to enable `group-hover` transitions on the arrow icon.
- Refactored `ScrollToTop.tsx` to move `fixed` positioning to a wrapper `div`, ensuring stable tooltip placement.
- Fixed pre-existing linting errors (`react-hooks/refs`) in `useTaskManagement.ts` and `use-cache.ts` by moving ref assignments into `useEffect`.

### 🎯 Why:
- Improves discoverability: Users now see a "Back to top" hint when hovering or focusing the button.
- Visual delight: Restores the intended upward translation animation of the arrow icon on hover.
- Reliability: Fixes critical linting errors that would block CI/CD pipelines.

### ♿ Accessibility:
- Added visual tooltip context for icon-only button.
- Maintained existing `aria-label` and `sr-only` text.
- Ensured keyboard focus still triggers the tooltip.

### ✅ Verification:
- All unit tests pass (`pnpm test`).
- Linting checks pass (`pnpm lint`).
- Visual verification performed via Playwright screenshots.

---
*PR created automatically by Jules for task [13915784404158866218](https://jules.google.com/task/13915784404158866218) started by @cpa03*