### PR TITLE
🎨 Palette: Improve TaskItem metadata accessibility and tooltips

### DIFF
--- a/src/components/task-management/TaskItem.tsx
+++ b/src/components/task-management/TaskItem.tsx
@@ -10,7 +10,7 @@ import {
   TASK_ITEM_STYLES,
   TASK_MANAGEMENT_MESSAGES,
 } from '@/lib/config';
-import Tooltip from '../Tooltip';
+import Tooltip from '@/components/Tooltip';
 
 interface TaskItemProps {
   task: Task;

--- a/src/components/task-management/TaskItem.tsx
+++ b/src/components/task-management/TaskItem.tsx
@@ -127,51 +127,79 @@ function TaskItemComponent({ task, isUpdating, onToggle }: TaskItemProps) {
 
         <div className={TASK_ITEM_STYLES.METADATA.CONTAINER}>
           {task.estimate > 0 && (
-            <span className="flex items-center gap-1">
-              <svg
-                className={TASK_ITEM_STYLES.METADATA.ICON}
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-                aria-hidden="true"
+            <Tooltip
+              content={TASK_MANAGEMENT_MESSAGES.METADATA.ESTIMATE(task.estimate)}
+            >
+              <span
+                className={TASK_ITEM_STYLES.METADATA.ITEM}
+                role="img"
+                aria-label={TASK_MANAGEMENT_MESSAGES.METADATA.ESTIMATE(
+                  task.estimate
+                )}
               >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
-                />
-              </svg>
-              {task.estimate}h
-            </span>
+                <svg
+                  className={TASK_ITEM_STYLES.METADATA.ICON}
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
+                  />
+                </svg>
+                {task.estimate}h
+              </span>
+            </Tooltip>
           )}
           {task.assignee && (
-            <span className="flex items-center gap-1">
-              <svg
-                className={TASK_ITEM_STYLES.METADATA.ICON}
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-                aria-hidden="true"
+            <Tooltip
+              content={TASK_MANAGEMENT_MESSAGES.METADATA.ASSIGNEE(task.assignee)}
+            >
+              <span
+                className={TASK_ITEM_STYLES.METADATA.ITEM}
+                role="img"
+                aria-label={TASK_MANAGEMENT_MESSAGES.METADATA.ASSIGNEE(
+                  task.assignee
+                )}
               >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
-                />
-              </svg>
-              {task.assignee}
-            </span>
+                <svg
+                  className={TASK_ITEM_STYLES.METADATA.ICON}
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
+                  />
+                </svg>
+                {task.assignee}
+              </span>
+            </Tooltip>
           )}
           {task.risk_level !== 'low' && (
-            <span
-              className={`${TASK_ITEM_STYLES.METADATA.RISK_BADGE} ${
-                RISK_LEVEL_CONFIG[task.risk_level].bgColor
-              } ${RISK_LEVEL_CONFIG[task.risk_level].textColor}`}
+            <Tooltip
+              content={TASK_MANAGEMENT_MESSAGES.METADATA.RISK(task.risk_level)}
             >
-              {task.risk_level} risk
-            </span>
+              <span
+                className={`${TASK_ITEM_STYLES.METADATA.ITEM} ${
+                  RISK_LEVEL_CONFIG[task.risk_level].bgColor
+                } ${RISK_LEVEL_CONFIG[task.risk_level].textColor}`}
+                role="img"
+                aria-label={TASK_MANAGEMENT_MESSAGES.METADATA.RISK(
+                  task.risk_level
+                )}
+              >
+                {task.risk_level} risk
+              </span>
+            </Tooltip>
           )}
         </div>
       </div>

--- a/src/hooks/useTaskManagement.ts
+++ b/src/hooks/useTaskManagement.ts
@@ -60,7 +60,9 @@ export function useTaskManagement(ideaId: string): UseTaskManagementReturn {
   // PERFORMANCE: Use a ref to keep track of the latest data without triggering
   // re-creations of callbacks that depend on it.
   const dataRef = useRef(data);
-  dataRef.current = data;
+  useEffect(() => {
+    dataRef.current = data;
+  }, [data]);
 
   // Fetch tasks on mount
   useEffect(() => {

--- a/src/lib/config/task-management.ts
+++ b/src/lib/config/task-management.ts
@@ -111,6 +111,7 @@ export const TASK_ITEM_STYLES = {
     CONTAINER: 'flex flex-wrap items-center gap-2 mt-2 text-xs text-gray-500',
     ICON: 'w-3 h-3',
     RISK_BADGE: 'px-1.5 py-0.5 rounded',
+    ITEM: 'flex items-center gap-1 px-1.5 py-0.5 rounded-md transition-colors hover:bg-gray-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-1 cursor-default',
   },
 } as const;
 
@@ -224,6 +225,12 @@ export const TASK_MANAGEMENT_MESSAGES = {
       isCompleted
         ? `Mark "${taskTitle}" as incomplete`
         : `Mark "${taskTitle}" as complete`,
+  },
+  METADATA: {
+    ESTIMATE: (hours: number) =>
+      `Estimated time: ${hours} ${hours === 1 ? 'hour' : 'hours'}`,
+    ASSIGNEE: (name: string) => `Assigned to ${name}`,
+    RISK: (level: string) => `${level.charAt(0).toUpperCase() + level.slice(1)} risk level`,
   },
 } as const;
 

--- a/src/lib/use-cache.ts
+++ b/src/lib/use-cache.ts
@@ -35,7 +35,9 @@ export function useCache<T>(
   // Use ref to avoid dependency on fetcher function identity
   // This prevents infinite re-renders when fetcher is not memoized by caller
   const fetcherRef = useRef(fetcher);
-  fetcherRef.current = fetcher;
+  useEffect(() => {
+    fetcherRef.current = fetcher;
+  }, [fetcher]);
 
   const revalidate = useCallback(async () => {
     try {


### PR DESCRIPTION
This PR implements a micro-UX improvement to the Task Management interface by enhancing the accessibility and scannability of task metadata.

### 💡 What:
- Added `Tooltip` components to task metadata items (estimates, assignees, and risk levels).
- Replaced cryptic short labels (e.g., "2h") with descriptive screen reader text ("Estimated time: 2 hours").
- Centralized tooltip message templates and item styling in the task management configuration.
- Fixed pre-existing lint errors in `useTaskManagement.ts` and `use-cache.ts` by moving ref updates into `useEffect`.

### 🎯 Why:
Users often find it difficult to understand icon-only or shortened metadata at a glance. Adding tooltips provides immediate context on hover, and enhanced ARIA labels ensure that users with screen readers receive full information about the task's properties.

### ♿ Accessibility:
- Added descriptive `aria-label` to metadata items.
- Used `role="img"` for metadata items to convey they are informational assets.
- Intentionally avoided `tabIndex={0}` on metadata to prevent keyboard navigation bloat in list views, prioritizing a clean tab order.

### ✅ Verification:
- Verified visually with Playwright screenshots showing tooltips on hover.
- Ran `pnpm lint` and all relevant tests (tasks-api, accessibility).
- Fixed unrelated linting issues to ensure a clean build.

---
*PR created automatically by Jules for task [16980899074120996542](https://jules.google.com/task/16980899074120996542) started by @cpa03*