### PR TITLE
🎨 Palette: Add tooltips to task metadata and fix hour pluralization

### DIFF
--- a/src/components/task-management/DeliverableCard.tsx
+++ b/src/components/task-management/DeliverableCard.tsx
@@ -5,10 +5,10 @@ import type { Task } from '@/lib/db';
 import { TaskItem } from './TaskItem';
 import type { TaskStatus } from '@/types/task';
 import {
-  DELIVERABLE_STYLES,
   DELIVERABLE_CARD_STYLES,
   DELIVERABLE_PROGRESS_CONFIG,
-} from '@/lib/config';
+} from '@/lib/config/task-management';
+import { DELIVERABLE_STYLES } from '@/lib/config/theme';
 
 interface DeliverableWithTasks {
   id: string;

--- a/src/components/task-management/TaskItem.tsx
+++ b/src/components/task-management/TaskItem.tsx
@@ -127,42 +127,54 @@ function TaskItemComponent({ task, isUpdating, onToggle }: TaskItemProps) {
 
         <div className={TASK_ITEM_STYLES.METADATA.CONTAINER}>
           {task.estimate > 0 && (
-            <span className="flex items-center gap-1">
-              <svg
-                className={TASK_ITEM_STYLES.METADATA.ICON}
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-                aria-hidden="true"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
-                />
-              </svg>
-              {task.estimate}h
-            </span>
+            <Tooltip
+              content={TASK_MANAGEMENT_MESSAGES.ARIA.ESTIMATE_TOOLTIP(
+                task.estimate
+              )}
+            >
+              <span className="flex items-center gap-1 cursor-help">
+                <svg
+                  className={TASK_ITEM_STYLES.METADATA.ICON}
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
+                  />
+                </svg>
+                {task.estimate}h
+              </span>
+            </Tooltip>
           )}
           {task.assignee && (
-            <span className="flex items-center gap-1">
-              <svg
-                className={TASK_ITEM_STYLES.METADATA.ICON}
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-                aria-hidden="true"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
-                />
-              </svg>
-              {task.assignee}
-            </span>
+            <Tooltip
+              content={TASK_MANAGEMENT_MESSAGES.ARIA.ASSIGNEE_TOOLTIP(
+                task.assignee
+              )}
+            >
+              <span className="flex items-center gap-1 cursor-help">
+                <svg
+                  className={TASK_ITEM_STYLES.METADATA.ICON}
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
+                  />
+                </svg>
+                {task.assignee}
+              </span>
+            </Tooltip>
           )}
           {task.risk_level !== 'low' && (
             <span

--- a/src/components/task-management/TaskItem.tsx
+++ b/src/components/task-management/TaskItem.tsx
@@ -4,13 +4,13 @@ import { memo, useCallback, useMemo } from 'react';
 import type { Task } from '@/lib/db';
 import type { TaskStatus } from '@/types/task';
 import {
-  SVG_ANIMATION,
   TASK_STATUS_CONFIG,
   RISK_LEVEL_CONFIG,
   TASK_ITEM_STYLES,
   TASK_MANAGEMENT_MESSAGES,
-} from '@/lib/config';
-import Tooltip from '../Tooltip';
+} from '@/lib/config/task-management';
+import { SVG_ANIMATION } from '@/lib/config/theme';
+import Tooltip from '@/components/Tooltip';
 
 interface TaskItemProps {
   task: Task;

--- a/src/components/task-management/TaskManagementHeader.tsx
+++ b/src/components/task-management/TaskManagementHeader.tsx
@@ -2,7 +2,8 @@
 
 import { memo, useMemo } from 'react';
 import Button from '@/components/Button';
-import { MESSAGES, TASK_HEADER_STYLES } from '@/lib/config';
+import { TASK_HEADER_STYLES } from '@/lib/config/task-management';
+import { MESSAGES } from '@/lib/config/ui';
 
 interface TaskManagementHeaderProps {
   totalDeliverables: number;

--- a/src/lib/config/task-management.ts
+++ b/src/lib/config/task-management.ts
@@ -224,6 +224,9 @@ export const TASK_MANAGEMENT_MESSAGES = {
       isCompleted
         ? `Mark "${taskTitle}" as incomplete`
         : `Mark "${taskTitle}" as complete`,
+    ESTIMATE_TOOLTIP: (hours: number) =>
+      `Estimate: ${hours} ${hours === 1 ? 'hour' : 'hours'}`,
+    ASSIGNEE_TOOLTIP: (assignee: string) => `Assigned to: ${assignee}`,
   },
 } as const;
 


### PR DESCRIPTION
I've implemented a micro-UX improvement by adding accessible tooltips to the task metadata icons (estimate and assignee) in the `TaskItem` component. 

Key changes:
- Wrapped the estimate and assignee metadata in `Tooltip` components.
- Added `ESTIMATE_TOOLTIP` and `ASSIGNEE_TOOLTIP` to `TASK_MANAGEMENT_MESSAGES` in `src/lib/config/task-management.ts`.
- Implemented pluralization logic for the estimate tooltip (e.g., "Estimate: 1 hour" vs "Estimate: 2 hours").
- Added `cursor-help` class to metadata spans to indicate they have tooltips.

Verified the changes via:
- Playwright screenshot verification showing tooltips appearing on hover with correct pluralization.
- Running `pnpm test:ci` and `pnpm run type-check`.
- Manual inspection of accessibility attributes.

♿ Accessibility:
- Added descriptive tooltips for icon-only metadata, providing context for sighted users.
- Maintained existing `aria-label` and `aria-pressed` for the task checkbox.
- Ensured tooltips are accessible via hover and focus.

---
*PR created automatically by Jules for task [1077356761402466615](https://jules.google.com/task/1077356761402466615) started by @cpa03*