### PR TITLE
⚡ Bolt: optimize task management re-renders

### DIFF
--- a/src/hooks/useABTest.ts
+++ b/src/hooks/useABTest.ts
@@ -7,7 +7,7 @@
 
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { getAssignment, ABAssignment, AB_TEST_CONFIG } from '@/lib/ab-test';
 
 /**
@@ -66,18 +66,26 @@ export function useABTest(
     setIsLoaded(true);
   }, [experimentKey, enabled]);
 
-  const isInVariant = (variantId: string): boolean => {
-    return variant === variantId;
-  };
+  const isInVariant = useCallback(
+    (variantId: string): boolean => {
+      return variant === variantId;
+    },
+    [variant]
+  );
 
-  return {
-    variant,
-    isControl: variant === 'control',
-    isInVariant,
-    isEnabled: enabled,
-    isLoaded,
-    assignment,
-  };
+  // PERFORMANCE: Memoize the return object to ensure referential stability.
+  // This prevents unnecessary re-renders in components that consume this hook.
+  return useMemo(
+    () => ({
+      variant,
+      isControl: variant === 'control',
+      isInVariant,
+      isEnabled: enabled,
+      isLoaded,
+      assignment,
+    }),
+    [variant, isInVariant, enabled, isLoaded, assignment]
+  );
 }
 
 /**

--- a/src/hooks/useFunnelTracking.ts
+++ b/src/hooks/useFunnelTracking.ts
@@ -9,7 +9,7 @@
 
 'use client';
 
-import { useCallback, useRef, useEffect } from 'react';
+import { useCallback, useRef, useEffect, useMemo } from 'react';
 import { trackFunnelStep, trackFunnelDropoff, flush } from '@/lib/analytics';
 
 /**
@@ -161,12 +161,17 @@ export function useFunnelTracking(
     return currentStepRef.current;
   }, []);
 
-  return {
-    completeStep,
-    markDropoff,
-    reset,
-    getCurrentStep,
-  };
+  // PERFORMANCE: Memoize the return object to ensure referential stability.
+  // This prevents unnecessary re-renders in components that consume this hook.
+  return useMemo(
+    () => ({
+      completeStep,
+      markDropoff,
+      reset,
+      getCurrentStep,
+    }),
+    [completeStep, markDropoff, reset, getCurrentStep]
+  );
 }
 
 /**

--- a/src/hooks/useTaskManagement.ts
+++ b/src/hooks/useTaskManagement.ts
@@ -44,6 +44,85 @@ interface UseTaskManagementReturn {
   collapseAll: () => void;
 }
 
+// PERFORMANCE: Move pure helper outside the hook to ensure it has a static identity.
+// This prevents recreation of callbacks that depend on this logic.
+const applyTaskStatusUpdate = (
+  prevData: TasksResponse | null,
+  taskId: string,
+  newStatus: TaskStatus
+): TasksResponse | null => {
+  if (!prevData) return null;
+
+  const dIndex = prevData.deliverables.findIndex((d) =>
+    d.tasks.some((t) => t.id === taskId)
+  );
+  if (dIndex === -1) return prevData;
+
+  const deliverable = prevData.deliverables[dIndex];
+  const taskIndex = deliverable.tasks.findIndex((t) => t.id === taskId);
+  const task = deliverable.tasks[taskIndex];
+  const est = Number(task.estimate) || 0;
+
+  let deltaTasks = 0;
+  let deltaHours = 0;
+
+  if (newStatus === 'completed' && task.status !== 'completed') {
+    deltaTasks = 1;
+    deltaHours = est;
+  } else if (newStatus !== 'completed' && task.status === 'completed') {
+    deltaTasks = -1;
+    deltaHours = -est;
+  }
+
+  if (deltaTasks === 0) return prevData;
+
+  const updatedTasks = [...deliverable.tasks];
+  updatedTasks[taskIndex] = {
+    ...task,
+    status: newStatus,
+    completion_percentage: newStatus === 'completed' ? 100 : 0,
+  };
+
+  const newCompletedCount = deliverable.completedCount + deltaTasks;
+  const newCompletedHours =
+    Math.round((deliverable.completedHours + deltaHours) * 10) / 10;
+
+  const updatedDeliverable = {
+    ...deliverable,
+    tasks: updatedTasks,
+    completedCount: newCompletedCount,
+    completedHours: newCompletedHours,
+    progress: Math.round(
+      updatedTasks.length > 0
+        ? (newCompletedCount / updatedTasks.length) * 100
+        : 0
+    ),
+  };
+
+  const updatedDeliverables = [...prevData.deliverables];
+  updatedDeliverables[dIndex] = updatedDeliverable;
+
+  const { summary } = prevData;
+  const newOverallCompletedTasks = summary.completedTasks + deltaTasks;
+  const newOverallCompletedHours =
+    Math.round((summary.completedHours + deltaHours) * 10) / 10;
+
+  return {
+    ...prevData,
+    deliverables: updatedDeliverables,
+    summary: {
+      ...summary,
+      completedTasks: newOverallCompletedTasks,
+      completedHours: newOverallCompletedHours,
+      overallProgress: Math.round(
+        summary.totalTasks > 0
+          ? (newOverallCompletedTasks / summary.totalTasks) * 100
+          : 0
+      ),
+    },
+  };
+};
+
 export function useTaskManagement(ideaId: string): UseTaskManagementReturn {
   const logger = useMemo(() => createLogger('TaskManagement'), []);
   const [loading, setLoading] = useState(true);
@@ -58,9 +137,13 @@ export function useTaskManagement(ideaId: string): UseTaskManagementReturn {
   const previousDataRef = useRef<TasksResponse | null>(null);
 
   // PERFORMANCE: Use a ref to keep track of the latest data without triggering
-  // re-creations of callbacks that depend on it.
+  // re-creations of callbacks that depend on it. We update this in an effect
+  // to maintain render-phase purity and satisfy lint rules.
   const dataRef = useRef(data);
-  dataRef.current = data;
+
+  useEffect(() => {
+    dataRef.current = data;
+  }, [data]);
 
   // Fetch tasks on mount
   useEffect(() => {
@@ -114,87 +197,6 @@ export function useTaskManagement(ideaId: string): UseTaskManagementReturn {
     }
   }, [ideaId, logger]);
 
-  // Helper function to apply task status update to state
-  const applyTaskStatusUpdate = useCallback(
-    (
-      prevData: TasksResponse | null,
-      taskId: string,
-      newStatus: TaskStatus
-    ): TasksResponse | null => {
-      if (!prevData) return null;
-
-      const dIndex = prevData.deliverables.findIndex((d) =>
-        d.tasks.some((t) => t.id === taskId)
-      );
-      if (dIndex === -1) return prevData;
-
-      const deliverable = prevData.deliverables[dIndex];
-      const taskIndex = deliverable.tasks.findIndex((t) => t.id === taskId);
-      const task = deliverable.tasks[taskIndex];
-      const est = Number(task.estimate) || 0;
-
-      let deltaTasks = 0;
-      let deltaHours = 0;
-
-      if (newStatus === 'completed' && task.status !== 'completed') {
-        deltaTasks = 1;
-        deltaHours = est;
-      } else if (newStatus !== 'completed' && task.status === 'completed') {
-        deltaTasks = -1;
-        deltaHours = -est;
-      }
-
-      if (deltaTasks === 0) return prevData;
-
-      const updatedTasks = [...deliverable.tasks];
-      updatedTasks[taskIndex] = {
-        ...task,
-        status: newStatus,
-        completion_percentage: newStatus === 'completed' ? 100 : 0,
-      };
-
-      const newCompletedCount = deliverable.completedCount + deltaTasks;
-      const newCompletedHours =
-        Math.round((deliverable.completedHours + deltaHours) * 10) / 10;
-
-      const updatedDeliverable = {
-        ...deliverable,
-        tasks: updatedTasks,
-        completedCount: newCompletedCount,
-        completedHours: newCompletedHours,
-        progress: Math.round(
-          updatedTasks.length > 0
-            ? (newCompletedCount / updatedTasks.length) * 100
-            : 0
-        ),
-      };
-
-      const updatedDeliverables = [...prevData.deliverables];
-      updatedDeliverables[dIndex] = updatedDeliverable;
-
-      const { summary } = prevData;
-      const newOverallCompletedTasks = summary.completedTasks + deltaTasks;
-      const newOverallCompletedHours =
-        Math.round((summary.completedHours + deltaHours) * 10) / 10;
-
-      return {
-        ...prevData,
-        deliverables: updatedDeliverables,
-        summary: {
-          ...summary,
-          completedTasks: newOverallCompletedTasks,
-          completedHours: newOverallCompletedHours,
-          overallProgress: Math.round(
-            summary.totalTasks > 0
-              ? (newOverallCompletedTasks / summary.totalTasks) * 100
-              : 0
-          ),
-        },
-      };
-    },
-    []
-  );
-
   // Toggle task status with OPTIMISTIC updates
   const handleToggleTaskStatus = useCallback(
     async (taskId: string, currentStatus: TaskStatus) => {
@@ -202,11 +204,11 @@ export function useTaskManagement(ideaId: string): UseTaskManagementReturn {
         currentStatus === 'completed' ? 'todo' : 'completed';
 
       // Store previous state for potential rollback
-      previousDataRef.current = data;
+      previousDataRef.current = dataRef.current;
 
       // Find the task for toast message BEFORE making changes
       const findTask = () => {
-        return data?.deliverables
+        return dataRef.current?.deliverables
           .flatMap((d) => d.tasks)
           .find((t) => t.id === taskId);
       };
@@ -293,7 +295,7 @@ export function useTaskManagement(ideaId: string): UseTaskManagementReturn {
         setUpdatingTaskId(null);
       }
     },
-    [data, logger, applyTaskStatusUpdate]
+    [logger]
   );
 
   // Toggle deliverable expansion
@@ -323,15 +325,30 @@ export function useTaskManagement(ideaId: string): UseTaskManagementReturn {
     setExpandedDeliverables(new Set());
   }, []);
 
-  return {
-    loading,
-    error,
-    data,
-    updatingTaskId,
-    expandedDeliverables,
-    handleToggleTaskStatus,
-    toggleDeliverable,
-    expandAll,
-    collapseAll,
-  };
+  // PERFORMANCE: Memoize the return object to ensure referential stability.
+  // This prevents unnecessary re-renders in components that consume this hook.
+  return useMemo(
+    () => ({
+      loading,
+      error,
+      data,
+      updatingTaskId,
+      expandedDeliverables,
+      handleToggleTaskStatus,
+      toggleDeliverable,
+      expandAll,
+      collapseAll,
+    }),
+    [
+      loading,
+      error,
+      data,
+      updatingTaskId,
+      expandedDeliverables,
+      handleToggleTaskStatus,
+      toggleDeliverable,
+      expandAll,
+      collapseAll,
+    ]
+  );
 }

--- a/tests/hooks/useFunnelTracking.test.ts
+++ b/tests/hooks/useFunnelTracking.test.ts
@@ -1,0 +1,58 @@
+import { renderHook } from '@testing-library/react';
+import { useFunnelTracking } from '../../src/hooks/useFunnelTracking';
+
+// Mock analytics to prevent actual tracking during tests
+jest.mock('../../src/lib/analytics', () => ({
+  trackFunnelStep: jest.fn(),
+  trackFunnelDropoff: jest.fn(),
+  flush: jest.fn(),
+}));
+
+describe('useFunnelTracking', () => {
+  const mockConfig = {
+    name: 'test_funnel',
+    totalSteps: 3,
+  };
+
+  it('should maintain referential stability of the return object', () => {
+    const { result, rerender } = renderHook(() => useFunnelTracking(mockConfig));
+
+    const firstRenderResult = result.current;
+
+    // Rerender with the same config
+    rerender();
+
+    expect(result.current).toBe(firstRenderResult);
+  });
+
+  it('should maintain referential stability of functions', () => {
+    const { result, rerender } = renderHook(() => useFunnelTracking(mockConfig));
+
+    const { completeStep, markDropoff, reset, getCurrentStep } = result.current;
+
+    rerender();
+
+    expect(result.current.completeStep).toBe(completeStep);
+    expect(result.current.markDropoff).toBe(markDropoff);
+    expect(result.current.reset).toBe(reset);
+    expect(result.current.getCurrentStep).toBe(getCurrentStep);
+  });
+
+  it('should update referential identity when config changes', () => {
+    const { result, rerender } = renderHook(({ config }) => useFunnelTracking(config), {
+      initialProps: { config: mockConfig },
+    });
+
+    const firstRenderResult = result.current;
+
+    // Rerender with a different config
+    rerender({
+      config: {
+        name: 'different_funnel',
+        totalSteps: 5,
+      },
+    });
+
+    expect(result.current).not.toBe(firstRenderResult);
+  });
+});


### PR DESCRIPTION
💡 What: Optimized the `useTaskManagement` hook by stabilizing callbacks and memoizing the return object.
🎯 Why: Prevents unnecessary re-renders of the entire task list when a single task is toggled.
📊 Impact: Reduces re-renders of `TaskItem` and `DeliverableCard` components by ensuring referential stability of the `onToggleTask` prop.
🔬 Measurement: Verified with a test script confirming `handleToggleTaskStatus` identity remains stable across re-renders.

---
*PR created automatically by Jules for task [5716183191459415446](https://jules.google.com/task/5716183191459415446) started by @cpa03*