### PR TITLE
🎨 Palette: Add tooltip and fix animation for ScrollToTop

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/components/ScrollToTop.tsx
+++ b/src/components/ScrollToTop.tsx
@@ -9,6 +9,7 @@ import React, {
   memo,
 } from 'react';
 import { COMPONENT_DEFAULTS } from '@/lib/config';
+import Tooltip from './Tooltip';
 
 interface ScrollToTopProps {
   showAt?: number;
@@ -110,28 +111,34 @@ function ScrollToTopComponent({
     circumference - (scrollProgress / 100) * circumference;
 
   return (
-    <button
-      onClick={scrollToTop}
-      onKeyDown={handleKeyDown}
+    <div
       className={`
         fixed bottom-8 right-8 z-50
-        w-12 h-12
-        flex items-center justify-center
-        bg-white text-gray-700
-        rounded-full shadow-lg
-        border border-gray-200
-        transition-all duration-300 ease-out
-        hover:bg-gray-50 hover:text-primary-600 hover:shadow-xl hover:scale-110
-        hover:border-primary-200
-        focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2
-        active:scale-95
         ${prefersReducedMotion ? '' : 'animate-in fade-in slide-in-from-bottom-4 duration-300'}
-        ${className}
       `}
-      aria-label={`Scroll to top of page (${Math.round(scrollProgress)}% scrolled)`}
-      aria-live="polite"
-      type="button"
     >
+      <Tooltip content="Back to top" position="top">
+        <button
+          onClick={scrollToTop}
+          onKeyDown={handleKeyDown}
+          className={`
+            group
+            w-12 h-12
+            flex items-center justify-center
+            bg-white text-gray-700
+            rounded-full shadow-lg
+            border border-gray-200
+            transition-all duration-300 ease-out
+            hover:bg-gray-50 hover:text-primary-600 hover:shadow-xl hover:scale-110
+            hover:border-primary-200
+            focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2
+            active:scale-95
+            ${className}
+          `}
+          aria-label={`Scroll to top of page (${Math.round(scrollProgress)}% scrolled)`}
+          aria-live="polite"
+          type="button"
+        >
       {!prefersReducedMotion && (
         <svg
           className="absolute inset-0 w-full h-full -rotate-90 pointer-events-none"
@@ -186,8 +193,10 @@ function ScrollToTopComponent({
         />
       </svg>
 
-      <span className="sr-only">Back to top</span>
-    </button>
+          <span className="sr-only">Back to top</span>
+        </button>
+      </Tooltip>
+    </div>
   );
 }
 


### PR DESCRIPTION
💡 **What:** Added a visual tooltip to the "Scroll to top" button and fixed its hover animation.
🎯 **Why:** The button was icon-only and didn't have a visual label, making its purpose less immediately clear to some users. Additionally, the upward translation animation on the arrow icon was not triggering due to a missing `group` class on the parent button.
♿ **Accessibility:** The button now has a visible "Back to top" tooltip on hover/focus, complementing the existing `aria-label` and `sr-only` text for a better experience across all input methods.
📸 **Visuals:** A tooltip now appears above the button when hovered or focused.

---
*PR created automatically by Jules for task [466588979775746300](https://jules.google.com/task/466588979775746300) started by @cpa03*