### PR TITLE
🛡️ Sentinel: Fix JWT rate-limit collision vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,4 +1,4 @@
 ## 2026-02-23 - JWT Rate-Limit Identifier Collision
 **Vulnerability:** Authenticated users were sharing the same rate-limit bucket because identifiers were generated using only the first 32 characters of the Authorization token. Standard JWT headers are often identical and exceed 32 characters when encoded.
 **Learning:** Using substrings of structured tokens (like JWTs) for unique identification is insecure as it ignores the variable part of the token (the payload and signature).
-**Prevention:** Always hash the entire token or extract a verified unique claim (like `sub`) to generate identifiers. Deterministic non-cryptographic hashes like djb2 are sufficient for rate-limit keys.
+**Prevention:** Always hash the entire token or extract a verified unique claim (like 'sub') to generate identifiers. Deterministic non-cryptographic hashes like djb2 are sufficient for rate-limit keys.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-02-23 - JWT Rate-Limit Identifier Collision
+**Vulnerability:** Authenticated users were sharing the same rate-limit bucket because identifiers were generated using only the first 32 characters of the Authorization token. Standard JWT headers are often identical and exceed 32 characters when encoded.
+**Learning:** Using substrings of structured tokens (like JWTs) for unique identification is insecure as it ignores the variable part of the token (the payload and signature).
+**Prevention:** Always hash the entire token or extract a verified unique claim (like `sub`) to generate identifiers. Deterministic non-cryptographic hashes like djb2 are sufficient for rate-limit keys.

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -38,6 +38,24 @@ export interface UserRateLimitInfo {
 }
 
 /**
+ * Simple deterministic hash function (djb2)
+ * Used for anonymizing tokens and creating unique identifiers
+ *
+ * @param str - String to hash
+ * @returns 32-bit hash as base36 string
+ */
+function simpleHash(str: string): string {
+  let hash = 5381;
+  for (let i = 0; i < str.length; i++) {
+    // djb2 hash: hash * 33 + char
+    // Bitwise OR with 0 ensures 32-bit integer precision
+    hash = (((hash << 5) + hash) + str.charCodeAt(i)) | 0;
+  }
+  // Convert to unsigned 32-bit integer then base36 for a compact identifier
+  return (hash >>> 0).toString(36);
+}
+
+/**
  * Extract user ID from Supabase Authorization header
  *
  * The Supabase client sends the access token in the Authorization header
@@ -63,15 +81,9 @@ function extractUserIdFromRequest(request: Request): string | null {
     // For now, we can use the token as a unique identifier
     const token = authHeader.substring(7);
     if (token && token.length > 0) {
-      // Return a hash of the full token as the user identifier to prevent collisions.
-      // Identical headers in different JWTs would otherwise cause multiple users to share a limit.
-      // SECURITY: djb2 hash algorithm provides efficient anonymization and collision resistance for rate-limit keys.
-      let hash = 5381;
-      for (let i = 0; i < token.length; i++) {
-        const char = token.charCodeAt(i);
-        hash = ((hash << 5) + hash) ^ char; // hash * 33 ^ c
-      }
-      return `token:${(hash >>> 0).toString(36)}`;
+      // Return a hash of the full token as the user identifier to prevent collisions
+      // This ensures that users with different tokens don't share the same rate limit
+      return `token:${simpleHash(token)}`;
     }
   }
 
@@ -249,14 +261,7 @@ function generateRequestFingerprint(request: Request): string {
   // Combine characteristics with path
   const combined = `${urlPath}:${userAgent}:${acceptLang}:${acceptEncoding}`;
 
-  // Use djb2 hash algorithm for better distribution
-  let hash = 5381;
-  for (let i = 0; i < combined.length; i++) {
-    const char = combined.charCodeAt(i);
-    hash = ((hash << 5) + hash) ^ char; // hash * 33 ^ c
-  }
-
-  return `fp:${Math.abs(hash >>> 0)}`;
+  return `fp:${simpleHash(combined)}`;
 }
 
 /**

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -38,6 +38,23 @@ export interface UserRateLimitInfo {
 }
 
 /**
+ * Simple deterministic hash function (djb2)
+ * Used for anonymizing tokens and creating unique identifiers
+ *
+ * @param str - String to hash
+ * @returns 32-bit hash as base36 string
+ */
+function simpleHash(str: string): string {
+  let hash = 5381;
+  for (let i = 0; i < str.length; i++) {
+    const char = str.charCodeAt(i);
+    // hash * 33 + char
+    hash = ((hash << 5) + hash) ^ char;
+  }
+  return (hash >>> 0).toString(36);
+}
+
+/**
  * Extract user ID from Supabase Authorization header
  *
  * The Supabase client sends the access token in the Authorization header
@@ -63,9 +80,9 @@ function extractUserIdFromRequest(request: Request): string | null {
     // For now, we can use the token as a unique identifier
     const token = authHeader.substring(7);
     if (token && token.length > 0) {
-      // Return a hash of the token as the user identifier
-      // This is a simplified approach - in production, validate JWT properly
-      return `token:${token.substring(0, 32)}`;
+      // Return a hash of the full token as the user identifier to prevent collisions
+      // This ensures that users with different tokens don't share the same rate limit
+      return `token:${simpleHash(token)}`;
     }
   }
 
@@ -243,14 +260,7 @@ function generateRequestFingerprint(request: Request): string {
   // Combine characteristics with path
   const combined = `${urlPath}:${userAgent}:${acceptLang}:${acceptEncoding}`;
 
-  // Use djb2 hash algorithm for better distribution
-  let hash = 5381;
-  for (let i = 0; i < combined.length; i++) {
-    const char = combined.charCodeAt(i);
-    hash = ((hash << 5) + hash) ^ char; // hash * 33 ^ c
-  }
-
-  return `fp:${Math.abs(hash >>> 0)}`;
+  return `fp:${simpleHash(combined)}`;
 }
 
 /**

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -47,10 +47,11 @@ export interface UserRateLimitInfo {
 function simpleHash(str: string): string {
   let hash = 5381;
   for (let i = 0; i < str.length; i++) {
-    const char = str.charCodeAt(i);
-    // hash * 33 + char
-    hash = ((hash << 5) + hash) ^ char;
+    // djb2 hash: hash * 33 + char
+    // Bitwise OR with 0 ensures 32-bit integer precision
+    hash = (((hash << 5) + hash) + str.charCodeAt(i)) | 0;
   }
+  // Convert to unsigned 32-bit integer then base36 for a compact identifier
   return (hash >>> 0).toString(36);
 }
 

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -38,24 +38,6 @@ export interface UserRateLimitInfo {
 }
 
 /**
- * Simple deterministic hash function (djb2)
- * Used for anonymizing tokens and creating unique identifiers
- *
- * @param str - String to hash
- * @returns 32-bit hash as base36 string
- */
-function simpleHash(str: string): string {
-  let hash = 5381;
-  for (let i = 0; i < str.length; i++) {
-    // djb2 hash: hash * 33 + char
-    // Bitwise OR with 0 ensures 32-bit integer precision
-    hash = (((hash << 5) + hash) + str.charCodeAt(i)) | 0;
-  }
-  // Convert to unsigned 32-bit integer then base36 for a compact identifier
-  return (hash >>> 0).toString(36);
-}
-
-/**
  * Extract user ID from Supabase Authorization header
  *
  * The Supabase client sends the access token in the Authorization header
@@ -81,9 +63,15 @@ function extractUserIdFromRequest(request: Request): string | null {
     // For now, we can use the token as a unique identifier
     const token = authHeader.substring(7);
     if (token && token.length > 0) {
-      // Return a hash of the full token as the user identifier to prevent collisions
-      // This ensures that users with different tokens don't share the same rate limit
-      return `token:${simpleHash(token)}`;
+      // Return a hash of the full token as the user identifier to prevent collisions.
+      // Identical headers in different JWTs would otherwise cause multiple users to share a limit.
+      // SECURITY: djb2 hash algorithm provides efficient anonymization and collision resistance for rate-limit keys.
+      let hash = 5381;
+      for (let i = 0; i < token.length; i++) {
+        const char = token.charCodeAt(i);
+        hash = ((hash << 5) + hash) ^ char; // hash * 33 ^ c
+      }
+      return `token:${(hash >>> 0).toString(36)}`;
     }
   }
 
@@ -261,7 +249,14 @@ function generateRequestFingerprint(request: Request): string {
   // Combine characteristics with path
   const combined = `${urlPath}:${userAgent}:${acceptLang}:${acceptEncoding}`;
 
-  return `fp:${simpleHash(combined)}`;
+  // Use djb2 hash algorithm for better distribution
+  let hash = 5381;
+  for (let i = 0; i < combined.length; i++) {
+    const char = combined.charCodeAt(i);
+    hash = ((hash << 5) + hash) ^ char; // hash * 33 ^ c
+  }
+
+  return `fp:${Math.abs(hash >>> 0)}`;
 }
 
 /**

--- a/src/lib/session-analytics.ts
+++ b/src/lib/session-analytics.ts
@@ -88,13 +88,6 @@ function flushEvents(): void {
     logger.debug('[SessionAnalytics] Flush events:', eventsToSend);
   }
 
-  // Console log for now - can be extended to PostHog later
-  if (process.env.NODE_ENV !== 'production') {
-    console.log(
-      '[SessionAnalytics] Events:',
-      JSON.stringify(eventsToSend, null, 2)
-    );
-  }
 
   if (flushTimeout) {
     clearTimeout(flushTimeout);

--- a/src/lib/session-analytics.ts
+++ b/src/lib/session-analytics.ts
@@ -88,6 +88,13 @@ function flushEvents(): void {
     logger.debug('[SessionAnalytics] Flush events:', eventsToSend);
   }
 
+  // Console log for now - can be extended to PostHog later
+  if (process.env.NODE_ENV !== 'production') {
+    console.log(
+      '[SessionAnalytics] Events:',
+      JSON.stringify(eventsToSend, null, 2)
+    );
+  }
 
   if (flushTimeout) {
     clearTimeout(flushTimeout);


### PR DESCRIPTION
### 🚨 Severity: HIGH
### 💡 Vulnerability: JWT Rate-Limit Identifier Collision
Authenticated users were sharing the same rate-limit bucket because identifiers were generated using only the first 32 characters of the Authorization token. Standard JWT headers are often identical across users and exceed 32 characters when encoded, leading to a situation where the variable payload and signature were ignored.

### 🎯 Impact: 
A single user could accidentally or maliciously exhaust the rate limit for all other authenticated users (Denial of Service). It also incorrectly aggregated usage metrics across different accounts.

### 🔧 Fix:
Implemented a deterministic `simpleHash` (djb2) function to hash the full token. This ensures unique identifiers for every unique token while maintaining the anonymization property.

### ✅ Verification:
Verified using a reproduction script `reproduce-collision.ts` (deleted before submission) which confirmed that tokens sharing the same prefix now generate distinct identifiers.
Token 1: `user:token:1hqpgit`
Token 2: `user:token:1hqpgiu`

---
*PR created automatically by Jules for task [7381328775073529307](https://jules.google.com/task/7381328775073529307) started by @cpa03*