### PR TITLE
🎨 Palette: Add tooltip to ScrollToTop button

### DIFF
--- a/src/components/ScrollToTop.tsx
+++ b/src/components/ScrollToTop.tsx
@@ -9,6 +9,7 @@ import React, {
   memo,
 } from 'react';
 import { COMPONENT_DEFAULTS } from '@/lib/config';
+import Tooltip from './Tooltip';
 
 interface ScrollToTopProps {
   showAt?: number;
@@ -110,29 +111,31 @@ function ScrollToTopComponent({
     circumference - (scrollProgress / 100) * circumference;
 
   return (
-    <button
-      onClick={scrollToTop}
-      onKeyDown={handleKeyDown}
-      className={`
-        fixed bottom-8 right-8 z-50
-        w-12 h-12
-        flex items-center justify-center
-        bg-white text-gray-700
-        rounded-full shadow-lg
-        border border-gray-200
-        transition-all duration-300 ease-out
-        hover:bg-gray-50 hover:text-primary-600 hover:shadow-xl hover:scale-110
-        hover:border-primary-200
-        focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2
-        active:scale-95
-        ${prefersReducedMotion ? '' : 'animate-in fade-in slide-in-from-bottom-4 duration-300'}
-        ${className}
-      `}
-      aria-label={`Scroll to top of page (${Math.round(scrollProgress)}% scrolled)`}
-      aria-live="polite"
-      type="button"
-    >
-      {!prefersReducedMotion && (
+    <div className="fixed bottom-8 right-8 z-50">
+      <Tooltip content="Back to top" position="top">
+        <button
+          onClick={scrollToTop}
+          onKeyDown={handleKeyDown}
+          className={`
+            group
+            w-12 h-12
+            flex items-center justify-center
+            bg-white text-gray-700
+            rounded-full shadow-lg
+            border border-gray-200
+            transition-all duration-300 ease-out
+            hover:bg-gray-50 hover:text-primary-600 hover:shadow-xl hover:scale-110
+            hover:border-primary-200
+            focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2
+            active:scale-95
+            ${prefersReducedMotion ? '' : 'animate-in fade-in slide-in-from-bottom-4 duration-300'}
+            ${className}
+          `}
+          aria-label={`Scroll to top of page (${Math.round(scrollProgress)}% scrolled)`}
+          aria-live="polite"
+          type="button"
+        >
+          {!prefersReducedMotion && (
         <svg
           className="absolute inset-0 w-full h-full -rotate-90 pointer-events-none"
           viewBox="0 0 48 48"
@@ -186,8 +189,10 @@ function ScrollToTopComponent({
         />
       </svg>
 
-      <span className="sr-only">Back to top</span>
-    </button>
+          <span className="sr-only">Back to top</span>
+        </button>
+      </Tooltip>
+    </div>
   );
 }
 

--- a/src/lib/config/constants.ts
+++ b/src/lib/config/constants.ts
@@ -895,7 +895,6 @@ export const API_CACHE_CONFIG = {
 } as const;
 
 /**
-  HR|  ),
 } as const;
 
 /**


### PR DESCRIPTION
💡 What: Added a tooltip to the "Scroll to Top" button and enabled a subtle hover animation on the arrow icon.
🎯 Why: Icon-only buttons can be ambiguous for some users. A tooltip provides clear context ("Back to top") before interaction, making the interface more intuitive and accessible.
📸 Before/After: A screenshot `scroll-to-top-verify.png` was generated during verification showing the tooltip.
♿ Accessibility: Enhanced accessibility for sighted users by providing a descriptive text label on hover and focus. Maintains existing ARIA labels for screen readers.

---
*PR created automatically by Jules for task [70160286824866669](https://jules.google.com/task/70160286824866669) started by @cpa03*