### PR TITLE
⚡ Bolt: optimize useTaskManagement referential stability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,7 +114,6 @@ __pycache__/
 .worktrees/
 
 # Agent temporary directories
-# .jules/ is used for performance and security journals - unignore to persist across PRs
 # .jules/
 .Jules/
 .sisyphus/

--- a/.gitignore
+++ b/.gitignore
@@ -114,7 +114,8 @@ __pycache__/
 .worktrees/
 
 # Agent temporary directories
-.jules/
+# .jules/ is used for performance and security journals - unignore to persist across PRs
+# .jules/
 .Jules/
 .sisyphus/
 

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,9 @@
+## 2026-05-08 - Optimized Hook Referential Stability for Complex States
+
+**Learning:** In hooks managing large or complex datasets (like `useTaskManagement`), callbacks that depend on the data state (e.g., `handleToggleTaskStatus`) will change reference on every update. This causes O(N) re-renders in consumer components that render lists of items, even if those items are memoized. Using a `useRef` to track the latest state, updated inside a `useEffect` (to satisfy `react-hooks/refs`), allows callbacks to be referentially stable (O(1)) while still having access to the latest data.
+
+**Action:** For hooks returning stable callbacks that need access to volatile state:
+1. Use `useRef` to store the volatile state.
+2. Update the ref inside `useEffect(() => { ref.current = state; }, [state])`.
+3. Use `ref.current` inside `useCallback` and omit the state from dependencies.
+4. Memoize the hook's return object with `useMemo`.

--- a/src/hooks/useTaskManagement.ts
+++ b/src/hooks/useTaskManagement.ts
@@ -58,9 +58,13 @@ export function useTaskManagement(ideaId: string): UseTaskManagementReturn {
   const previousDataRef = useRef<TasksResponse | null>(null);
 
   // PERFORMANCE: Use a ref to keep track of the latest data without triggering
-  // re-creations of callbacks that depend on it.
+  // re-creations of callbacks that depend on it. We update this in useEffect
+  // to maintain render-phase purity and satisfy react-hooks/refs.
   const dataRef = useRef(data);
-  dataRef.current = data;
+
+  useEffect(() => {
+    dataRef.current = data;
+  }, [data]);
 
   // Fetch tasks on mount
   useEffect(() => {
@@ -196,17 +200,19 @@ export function useTaskManagement(ideaId: string): UseTaskManagementReturn {
   );
 
   // Toggle task status with OPTIMISTIC updates
+  // PERFORMANCE: This callback is now referentially stable (O(1)) by using dataRef
+  // instead of direct data dependency, preventing O(N) re-renders of task items.
   const handleToggleTaskStatus = useCallback(
     async (taskId: string, currentStatus: TaskStatus) => {
       const newStatus: TaskStatus =
         currentStatus === 'completed' ? 'todo' : 'completed';
 
       // Store previous state for potential rollback
-      previousDataRef.current = data;
+      previousDataRef.current = dataRef.current;
 
       // Find the task for toast message BEFORE making changes
       const findTask = () => {
-        return data?.deliverables
+        return dataRef.current?.deliverables
           .flatMap((d) => d.tasks)
           .find((t) => t.id === taskId);
       };
@@ -293,7 +299,7 @@ export function useTaskManagement(ideaId: string): UseTaskManagementReturn {
         setUpdatingTaskId(null);
       }
     },
-    [data, logger, applyTaskStatusUpdate]
+    [logger, applyTaskStatusUpdate]
   );
 
   // Toggle deliverable expansion
@@ -323,15 +329,29 @@ export function useTaskManagement(ideaId: string): UseTaskManagementReturn {
     setExpandedDeliverables(new Set());
   }, []);
 
-  return {
-    loading,
-    error,
-    data,
-    updatingTaskId,
-    expandedDeliverables,
-    handleToggleTaskStatus,
-    toggleDeliverable,
-    expandAll,
-    collapseAll,
-  };
+  // PERFORMANCE: Memoize return object to ensure referential stability for consumers
+  return useMemo(
+    () => ({
+      loading,
+      error,
+      data,
+      updatingTaskId,
+      expandedDeliverables,
+      handleToggleTaskStatus,
+      toggleDeliverable,
+      expandAll,
+      collapseAll,
+    }),
+    [
+      loading,
+      error,
+      data,
+      updatingTaskId,
+      expandedDeliverables,
+      handleToggleTaskStatus,
+      toggleDeliverable,
+      expandAll,
+      collapseAll,
+    ]
+  );
 }

--- a/src/lib/use-cache.ts
+++ b/src/lib/use-cache.ts
@@ -35,7 +35,10 @@ export function useCache<T>(
   // Use ref to avoid dependency on fetcher function identity
   // This prevents infinite re-renders when fetcher is not memoized by caller
   const fetcherRef = useRef(fetcher);
-  fetcherRef.current = fetcher;
+
+  useEffect(() => {
+    fetcherRef.current = fetcher;
+  }, [fetcher]);
 
   const revalidate = useCallback(async () => {
     try {


### PR DESCRIPTION
### 💡 What: The optimization implemented
Optimized the `useTaskManagement` hook for referential stability.

### 🎯 Why: The performance problem it solves
Previously, the `handleToggleTaskStatus` callback changed its reference every time the `data` state updated. Since this callback is passed to every `TaskItem` (via `DeliverableCard`), it caused all task items to re-render whenever any task status was toggled, even if the items were memoized. This resulted in O(N) re-render performance.

### 📊 Impact: Expected performance improvement
Achieves O(1) re-render performance for task items when toggling status. In a project with 50 tasks, this reduces re-renders from 50+ components to just the affected task item and its immediate parents.

### 🔬 Measurement: How to verify the improvement
Verified using a temporary test `tests/verify-task-perf.test.ts` (deleted before submission) which confirmed that `handleToggleTaskStatus` now maintains a stable reference across state updates.

---
*PR created automatically by Jules for task [1266947883982960435](https://jules.google.com/task/1266947883982960435) started by @cpa03*