### PR TITLE
⚡ Bolt: optimize useUserPreferences for referential stability and render-phase purity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,6 +115,8 @@ __pycache__/
 
 # Agent temporary directories
 .jules/
+!.jules/bolt.md
+!.jules/sentinel.md
 .Jules/
 .sisyphus/
 

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-05-14 - Optimized useUserPreferences for Referential Stability
+**Learning:** Returning unmemoized object literals from custom hooks causes all consumer components to re-render whenever the hook's parent re-renders, even if the actual state hasn't changed. Additionally, calling side-effects (like `localStorage.setItem`) inside `useState` updater functions violates render-phase purity and can lead to inconsistent state or performance bottlenecks.
+**Action:** Always wrap hook return objects in `useMemo` and ensure all returned functions are stable with `useCallback`. Move side-effects that persist state to a `useEffect` hook triggered by state changes.

--- a/src/hooks/useUserPreferences.ts
+++ b/src/hooks/useUserPreferences.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { createLogger } from '@/lib/logger';
 
 const logger = createLogger('useUserPreferences');
@@ -142,30 +142,28 @@ export function useUserPreferences(): UseUserPreferencesReturn {
     });
   }, []);
 
-  // Persist to localStorage whenever preferences change
-  const persistPreferences = useCallback((prefs: UserPreferences) => {
-    if (typeof window === 'undefined') return;
+  // PERFORMANCE: Use useEffect for persistence to maintain render-phase purity.
+  // This avoids calling side-effects (localStorage) inside state updater functions.
+  useEffect(() => {
+    // Skip persistence during initial load or on server
+    if (isLoading || typeof window === 'undefined') return;
 
     try {
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(prefs));
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(preferences));
       logger.debug('User preferences persisted');
     } catch (error) {
       logger.error('Failed to persist user preferences', error);
     }
-  }, []);
+  }, [preferences, isLoading]);
 
   /**
    * Update a single preference
    */
   const updatePreference = useCallback(
     <K extends keyof UserPreferences>(key: K, value: UserPreferences[K]) => {
-      setPreferences((prev) => {
-        const updated = { ...prev, [key]: value };
-        persistPreferences(updated);
-        return updated;
-      });
+      setPreferences((prev) => ({ ...prev, [key]: value }));
     },
-    [persistPreferences]
+    []
   );
 
   /**
@@ -173,13 +171,9 @@ export function useUserPreferences(): UseUserPreferencesReturn {
    */
   const updatePreferences = useCallback(
     (updates: Partial<UserPreferences>) => {
-      setPreferences((prev) => {
-        const updated = { ...prev, ...updates };
-        persistPreferences(updated);
-        return updated;
-      });
+      setPreferences((prev) => ({ ...prev, ...updates }));
     },
-    [persistPreferences]
+    []
   );
 
   /**
@@ -187,19 +181,15 @@ export function useUserPreferences(): UseUserPreferencesReturn {
    */
   const updateNotificationPreferences = useCallback(
     (updates: Partial<UserPreferences['notifications']>) => {
-      setPreferences((prev) => {
-        const updated = {
-          ...prev,
-          notifications: {
-            ...prev.notifications,
-            ...updates,
-          },
-        };
-        persistPreferences(updated);
-        return updated;
-      });
+      setPreferences((prev) => ({
+        ...prev,
+        notifications: {
+          ...prev.notifications,
+          ...updates,
+        },
+      }));
     },
-    [persistPreferences]
+    []
   );
 
   /**
@@ -210,18 +200,29 @@ export function useUserPreferences(): UseUserPreferencesReturn {
     defaults.firstVisit = Date.now();
     defaults.visitCount = 1;
     setPreferences(defaults);
-    persistPreferences(defaults);
     logger.info('User preferences reset to defaults');
-  }, [persistPreferences]);
+  }, []);
 
-  return {
-    preferences,
-    isLoading,
-    updatePreference,
-    updatePreferences,
-    updateNotificationPreferences,
-    resetPreferences,
-  };
+  // PERFORMANCE: Memoize the return object to ensure referential stability.
+  // This prevents unnecessary re-renders in consumer components that use this hook.
+  return useMemo(
+    () => ({
+      preferences,
+      isLoading,
+      updatePreference,
+      updatePreferences,
+      updateNotificationPreferences,
+      resetPreferences,
+    }),
+    [
+      preferences,
+      isLoading,
+      updatePreference,
+      updatePreferences,
+      updateNotificationPreferences,
+      resetPreferences,
+    ]
+  );
 }
 
 export default useUserPreferences;


### PR DESCRIPTION
💡 What: The optimization implemented
The `useUserPreferences` hook was refactored to ensure referential stability and render-phase purity.
- The return object is now wrapped in `useMemo`.
- The update functions (`updatePreference`, `updatePreferences`, etc.) are now stable with `useCallback`.
- The `localStorage` persistence logic was moved from the state updater functions into a `useEffect` hook.

🎯 Why: The performance problem it solves
Previously, `useUserPreferences` returned a new object literal on every render, causing all consumer components to re-render even if preferences hadn't changed. Also, performing side-effects (writing to `localStorage`) inside state updaters is a React anti-pattern that can cause performance bottlenecks and inconsistent behavior.

📊 Impact: Expected performance improvement
Reduces unnecessary re-renders in all components consuming `useUserPreferences`. Ensures the main thread is not unnecessarily blocked by synchronous `localStorage` calls during the state update transition.

🔬 Measurement: How to verify the improvement
Verified with a targeted test script that checks:
1. Referential stability of the return object when state hasn't changed.
2. Stability of the returned functions.
3. Correct persistence to `localStorage` via `useEffect`.

---
*PR created automatically by Jules for task [10176990960138155527](https://jules.google.com/task/10176990960138155527) started by @cpa03*