### PR TITLE
🎨 Palette: Enhance Alert dismissal with Tooltip and haptics

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -12,3 +12,7 @@
 ## 2026-02-25 - [Tooltip for Icon-Only Clear Button]
 **Learning:** Adding a tooltip to icon-only buttons (like a "Clear" button in an input field) provides essential context for users before they interact with it. To prevent the `Tooltip` component's `relative inline-flex` styles from disrupting the `absolute` positioning of elements within an input container, the `Tooltip` should be wrapped in an `absolute` positioned `div` that mirrors the original element's placement.
 **Action:** Always wrap `Tooltip` in an `absolute` positioned container when used for elements that require precise absolute placement within a parent.
+
+## 2026-05-11 - [Standalone Component Verification in Sandbox]
+**Learning:** Standalone frontend verification in the sandbox can be achieved by creating temporary routes (e.g., `src/app/verify-component/page.tsx`) to isolate UI elements for Playwright automation, bypassing complex environment variable validation or authentication flows of the main application.
+**Action:** Use temporary routes for isolated component testing when the main application has heavy environmental or auth requirements.

--- a/src/components/Alert.tsx
+++ b/src/components/Alert.tsx
@@ -3,6 +3,8 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { ANIMATION_CONFIG } from '@/lib/config/constants';
 import { ALERT_STYLES, ALERT_BASE_STYLES } from '@/lib/config';
+import { triggerHapticFeedback } from '@/lib/utils';
+import Tooltip from './Tooltip';
 
 interface AlertProps {
   type: 'error' | 'warning' | 'info' | 'success';
@@ -55,6 +57,7 @@ const AlertComponent = function Alert({
   const styles = ALERT_STYLES[type];
 
   const handleClose = useCallback(() => {
+    triggerHapticFeedback();
     setIsExiting(true);
     setTimeout(() => {
       setIsVisible(false);
@@ -109,27 +112,29 @@ const AlertComponent = function Alert({
         <div className={styles.textColor}>{children}</div>
       </div>
       {onClose && (
-        <button
-          onClick={handleClose}
-          className={`${ALERT_BASE_STYLES.closeButton} ${styles.textColor} ${styles.focusRing}`}
-          aria-label="Dismiss alert"
-          type="button"
-        >
-          <svg
-            className="w-4 h-4"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-            strokeWidth={2}
-            aria-hidden="true"
+        <Tooltip content="Dismiss alert" position="top">
+          <button
+            onClick={handleClose}
+            className={`${ALERT_BASE_STYLES.closeButton} ${styles.textColor} ${styles.focusRing}`}
+            aria-label="Dismiss alert"
+            type="button"
           >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              d="M6 18L18 6M6 6l12 12"
-            />
-          </svg>
-        </button>
+            <svg
+              className="w-4 h-4"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        </Tooltip>
       )}
     </div>
   );


### PR DESCRIPTION
### 💡 What: The UX enhancement added
Enhanced the `Alert` component's dismissal interaction by:
1.  Adding a **Tooltip** ("Dismiss alert") to the icon-only close button to provide visual context on hover/focus.
2.  Integrating **haptic feedback** using the `triggerHapticFeedback` utility to provide tactile confirmation when the alert is dismissed.

### 🎯 Why: The user problem it solves
Icon-only buttons can be ambiguous or easily overlooked. Adding a tooltip improves discoverability and clarity. Haptic feedback adds a "touch of delight" and physical confirmation for mobile users, making the interface feel more responsive and high-quality.

### 📸 Before/After: Screenshots if visual change
The "Dismiss alert" tooltip now appears when hovering over the 'X' button in any `Alert` component.

### ♿ Accessibility: Any a11y improvements made
- Improved button discoverability for sighted users through the visual Tooltip.
- Maintained existing `aria-label` for screen reader consistency.
- Ensured the tooltip is accessible via keyboard focus.


---
*PR created automatically by Jules for task [1221516404826449098](https://jules.google.com/task/1221516404826449098) started by @cpa03*