### PR TITLE
🛡️ Sentinel: Harden CSRF protection and consolidate hashing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** The rate-limiting logic in `src/lib/rate-limit.ts` was using the first 32 characters of the `Authorization` token as a user identifier. Since JWT headers are often identical for all users of an application, this caused all authenticated users to share a single rate-limit bucket, allowing a single user to trigger a global Denial of Service for all authenticated users.
 **Learning:** Modern authentication tokens like JWTs have a common header structure. Using a simple prefix for identification is insecure as it lacks sufficient entropy to distinguish between different users.
 **Prevention:** Always hash the entire token (or extract the unique `sub` claim) when using it for identification purposes. Implementing a consistent, 32-bit precision hash like djb2 with bitwise wrapping ensures collision resistance and cross-environment stability.
+
+## 2026-05-12 - Hardened CSRF missing header bypass
+**Vulnerability:** CSRF protection in `src/lib/security/csrf.ts` allowed state-changing requests (POST, PUT, etc.) to proceed even if they lacked both `Origin` and `Referer` headers. This created a bypass for browser-based CSRF attacks if the attacker could suppress these headers.
+**Learning:** Security logic often defaults to "allow" for edge cases (like missing headers) to avoid breaking unknown clients. However, for CSRF, browsers naturally send these headers, and their absence should be treated as suspicious for session-based requests.
+**Prevention:** Implement "fail secure" logic for CSRF by rejecting requests without origin indicators, while providing an explicit bypass for non-browser API traffic (detected via `Authorization` or custom API key headers) to maintain interoperability without compromising browser security.

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -9,6 +9,7 @@ import {
   RATE_LIMIT_CONFIG,
 } from './config/constants';
 import { generateRequestId } from './errors';
+import { simpleHash } from './security/crypto';
 
 export interface RateLimitInfo {
   limit: number;
@@ -213,20 +214,6 @@ function detectPlatform(): 'vercel' | 'cloudflare' | 'unknown' {
   return detectCloudflarePlatform();
 }
 
-/**
- * Simple, fast hash function (djb2) for non-cryptographic use.
- * Optimized for performance and 32-bit precision across environments.
- */
-function simpleHash(str: string): string {
-  let hash = 5381;
-  for (let i = 0; i < str.length; i++) {
-    const char = str.charCodeAt(i);
-    // Use bitwise OR with 0 to ensure 32-bit integer operations
-    hash = (((hash << 5) + hash) ^ char) | 0;
-  }
-  // Convert to unsigned 32-bit and then base36 for a compact string
-  return (hash >>> 0).toString(36);
-}
 
 /**
  * Generate a request fingerprint for fallback rate limiting

--- a/src/lib/security/csrf.ts
+++ b/src/lib/security/csrf.ts
@@ -77,24 +77,6 @@ function isTrustedOrigin(origin: string, trustedOrigins: string[]): boolean {
     if (normalizedOrigin === normalizedTrusted) {
       return true;
     }
-
-    // Check for exact subdomain match on Vercel (not all .vercel.app subdomains)
-    if (
-      normalizedTrusted.includes('.vercel.app') &&
-      normalizedOrigin.endsWith('.vercel.app') &&
-      normalizedOrigin === normalizedTrusted
-    ) {
-      return true;
-    }
-
-    // Check for exact subdomain match on Cloudflare Pages (not all .pages.dev subdomains)
-    if (
-      normalizedTrusted.includes('.pages.dev') &&
-      normalizedOrigin.endsWith('.pages.dev') &&
-      normalizedOrigin === normalizedTrusted
-    ) {
-      return true;
-    }
   }
 
   return false;
@@ -123,36 +105,41 @@ export function validateCSRF(
   }
 
   const origin = extractOrigin(request);
+  const requestId = request.headers.get('x-request-id');
 
   if (!origin) {
-    const requestUrl = request.url;
-    const requestOrigin = getOriginFromUrl(requestUrl);
+    // Allow requests without Origin/Referer if they have an Authorization or API Key header
+    // These are typical for server-to-server or CLI-based API requests and are
+    // inherently protected against CSRF as they aren't automatically sent by browsers.
+    const hasAuthHeader =
+      request.headers.has('authorization') || request.headers.has('x-api-key');
 
-    if (requestOrigin && isTrustedOrigin(requestOrigin, trustedOrigins)) {
-      return { valid: true, origin: requestOrigin };
+    if (hasAuthHeader) {
+      return { valid: true };
     }
 
     SecurityAuditLog.logEvent({
       timestamp: new Date().toISOString(),
-      category: 'configuration',
-      severity: 'low',
-      message:
-        'Request without origin header allowed (potential server-to-server)',
+      category: 'authentication',
+      severity: 'high',
+      message: 'CSRF validation failed: missing origin/referer headers',
+      requestId: requestId || undefined,
       metadata: {
         method,
-        url: requestUrl,
+        url: request.url,
       },
       environment: process.env.NODE_ENV || 'unknown',
     });
 
-    return { valid: true };
+    return {
+      valid: false,
+      error: 'Missing Origin or Referer header.',
+    };
   }
 
   if (isTrustedOrigin(origin, trustedOrigins)) {
     return { valid: true, origin };
   }
-
-  const requestId = request.headers.get('x-request-id');
 
   SecurityAuditLog.logEvent({
     timestamp: new Date().toISOString(),

--- a/src/lib/security/csrf.ts
+++ b/src/lib/security/csrf.ts
@@ -59,15 +59,6 @@ function extractOrigin(request: Request): string | null {
   return null;
 }
 
-function getOriginFromUrl(url: string): string | null {
-  try {
-    const parsedUrl = new URL(url);
-    return parsedUrl.origin.toLowerCase();
-  } catch {
-    return null;
-  }
-}
-
 function isTrustedOrigin(origin: string, trustedOrigins: string[]): boolean {
   const normalizedOrigin = origin.toLowerCase().replace(/\/$/, '');
 

--- a/tests/security/csrf.test.ts
+++ b/tests/security/csrf.test.ts
@@ -72,4 +72,27 @@ describe('CSRF Security', () => {
     const result = validateCSRF(request);
     expect(result.valid).toBe(true);
   });
+
+  it('should REJECT state-changing requests with NO origin or referer header', () => {
+    const request = new Request('https://myapp.com/api/action', {
+      method: 'POST',
+      headers: {}
+    });
+
+    const result = validateCSRF(request);
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('Missing Origin or Referer header');
+  });
+
+  it('should ALLOW state-changing requests with NO origin header IF they have an Authorization header', () => {
+    const request = new Request('https://myapp.com/api/action', {
+      method: 'POST',
+      headers: {
+        'Authorization': 'Bearer my-token'
+      }
+    });
+
+    const result = validateCSRF(request);
+    expect(result.valid).toBe(true);
+  });
 });


### PR DESCRIPTION
### 🛡️ Sentinel: Security Hardening

This PR addresses a potential CSRF bypass and improves the consistency of security-related hashing across the codebase.

#### 🚨 Severity: HIGH

#### 💡 Vulnerability: CSRF Header Bypass
The previous CSRF implementation allowed state-changing requests (POST, PUT, DELETE, PATCH) to proceed if they lacked both `Origin` and `Referer` headers, provided they were directed at a "trusted" server origin. An attacker could potentially exploit this by crafting requests that suppress these headers (e.g., via specific browser behaviors or misconfigurations).

#### 🔧 Fix
1.  **Harden CSRF Validation**: Modified `validateCSRF` to fail securely when origin indicators are missing.
2.  **API Interoperability**: Added an explicit exception for requests containing `Authorization` or `x-api-key` headers. Since these headers are not automatically sent by browsers and are typical for CLI/server-to-server traffic, they are inherently protected against standard CSRF attacks.
3.  **Consolidate Hashing**: Removed a duplicate implementation of `simpleHash` in the rate limiter, ensuring the entire application uses the hardened, cross-environment version from `src/lib/security/crypto.ts`.

#### ✅ Verification
- Ran `pnpm test tests/security/csrf.test.ts` (7 passing)
- Ran `pnpm test tests/rate-limit.test.ts` (54 passing)
- Verified with a new test case that unauthenticated headerless POST requests are rejected, while authenticated ones are allowed.
- Executed `pnpm security:check`.

---
*PR created automatically by Jules for task [8393634093931563698](https://jules.google.com/task/8393634093931563698) started by @cpa03*