### PR TITLE
🎨 Palette: Prevent premature tooltip text wrapping

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,5 @@
+# Palette's UX Journal
+
+## 2026-05-13 - Preventing Tooltip Premature Wrapping
+**Learning:** Tooltips using `whitespace-normal` with a `max-width` but no explicit width can wrap prematurely when the trigger element (parent) is narrow, as the tooltip container may shrink to fit the parent's width in certain layout contexts.
+**Action:** Add `w-max` (width: max-content) to tooltip containers to ensure they expand to fit their text content up to the `max-width` limit, regardless of the trigger element's size.

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -199,7 +199,7 @@ function TooltipComponent({
               className={`
                 px-2 py-1 bg-gray-800 text-white text-xs font-medium rounded-md
                 shadow-lg whitespace-normal
-                max-w-[200px] break-words
+                w-max max-w-[200px] break-words
               `}
             >
               {content}


### PR DESCRIPTION
This PR implements a micro-UX improvement to the `Tooltip` component to enhance readability and visual polish.

💡 **What:** Added `w-max` (width: max-content) to the Tooltip's inner content container.
🎯 **Why:** Short tooltips (like "Back to top") were wrapping prematurely when the trigger element was narrow. This was due to the container shrinking to the parent's width in certain layout contexts.
📸 **Verification:** Confirmed via Playwright screenshot that "Back to top" now displays on a single line above the 32px scroll-to-top button.
♿ **Accessibility:** Improved readability for all users, particularly those using screen magnifiers who might find multi-line wrapping in small popups distracting or harder to follow.

Changes:
- Modified `src/components/Tooltip.tsx` to include `w-max`.
- Created/Updated `.jules/palette.md` with critical learning.

---
*PR created automatically by Jules for task [3169526597785222734](https://jules.google.com/task/3169526597785222734) started by @cpa03*