### PR TITLE
⚡ Bolt: Memoize answers in ResultsPage to prevent redundant re-renders

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,7 @@
+## 2026-05-15 - Memoizing heavy component props in ResultsPage
+**Learning:** Object literals and inline transformations passed as props to memoized components (like `BlueprintDisplay`) trigger redundant re-renders because their reference changes every time the parent renders. This is especially impactful for components that manage complex async states or heavy DOM structures.
+**Action:** Always wrap derived objects or array transformations in `useMemo` when they are passed as props to components wrapped in `React.memo()`.
+
+## 2026-05-15 - Rules of Hooks and Early Returns
+**Learning:** Placing React hooks after early returns (e.g., `if (loading) return ...`) violates the Rules of Hooks and causes lint errors. This is particularly critical in environments with strict build checks like Cloudflare Workers.
+**Action:** Ensure all `useMemo`, `useEffect`, and other hooks are called at the top level of the component, before any conditional return statements.

--- a/src/app/results/page.tsx
+++ b/src/app/results/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, Suspense } from 'react';
+import { useState, useEffect, Suspense, useMemo } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { exportManager, exportUtils } from '@/lib/export-connectors';
 import { createLogger } from '@/lib/logger';
@@ -261,6 +261,20 @@ function ResultsContent() {
     }
   };
 
+  // PERFORMANCE: Memoize formatted answers to prevent unnecessary re-renders of memoized
+  // child components (BlueprintDisplay, EmailButton) when ResultsContent re-renders.
+  // NOTE: This must be called before any early returns to comply with Rules of Hooks.
+  const formattedAnswers = useMemo(() => {
+    return session?.state.answers && typeof session.state.answers === 'object'
+      ? Object.fromEntries(
+          Object.entries(session.state.answers).map(([key, value]) => [
+            key,
+            String(value),
+          ])
+        )
+      : {};
+  }, [session?.state.answers]);
+
   if (loading) {
     return (
       <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
@@ -320,19 +334,7 @@ function ResultsContent() {
         </Button>
       </div>
 
-      <BlueprintDisplay
-        idea={idea.raw_text}
-        answers={
-          session?.state.answers && typeof session.state.answers === 'object'
-            ? Object.fromEntries(
-                Object.entries(session.state.answers).map(([key, value]) => [
-                  key,
-                  String(value),
-                ])
-              )
-            : {}
-        }
-      />
+      <BlueprintDisplay idea={idea.raw_text} answers={formattedAnswers} />
 
       {/* Task Management */}
       <div className="mt-8">
@@ -491,16 +493,7 @@ function ResultsContent() {
           <EmailButton
             ideaTitle={idea.title}
             ideaContent={idea.raw_text}
-            sessionAnswers={
-              session?.state.answers &&
-              typeof session.state.answers === 'object'
-                ? Object.fromEntries(
-                    Object.entries(session.state.answers).map(
-                      ([key, value]) => [key, String(value)]
-                    )
-                  )
-                : {}
-            }
+            sessionAnswers={formattedAnswers}
             onEmailSent={() => {
               // Growth: Track email send event
               trackEvent(ANALYTICS_EVENTS.CTA_CLICK, {


### PR DESCRIPTION
I have implemented a performance optimization in the `ResultsPage` to improve referential stability and prevent unnecessary re-renders of child components.

### 💡 The Problem
In `src/app/results/page.tsx`, the `answers` object was being constructed inline as a new object literal in every render cycle. This object was then passed as a prop to `BlueprintDisplay` and `EmailButton`. Since these components are wrapped in `React.memo()`, the changing reference caused them to re-render even when the content of the answers remained the same.

### ⚡ The Solution
- Introduced `useMemo` to stabilize the `formattedAnswers` object.
- Ensured the hook is called before any early returns to satisfy the `react-hooks/rules-of-hooks` lint rule.
- Unified the transformation logic so both `BlueprintDisplay` and `EmailButton` use the same memoized reference.

### 📊 Performance Impact
- **Reduces re-renders** of heavy child components (especially `BlueprintDisplay` which handles blueprint generation) by avoiding referential instability.
- **Measurable Win:** Verified using a custom test runner that tracks render counts, confirming that parent state updates no longer trigger redundant child re-renders when the data is unchanged.

### ✅ Verification Results
- **Linting:** `pnpm lint` passes with no warnings.
- **Testing:** `pnpm test tests/BlueprintDisplay.test.tsx` passes.
- **Stability:** Confirmed through reproduction tests that memoization effectively blocks unnecessary re-renders.

---
*PR created automatically by Jules for task [5079369533622940254](https://jules.google.com/task/5079369533622940254) started by @cpa03*