### PR TITLE
🛡️ Sentinel: Harden A/B test randomness and expand PII redaction

### DIFF
--- a/src/lib/ab-test.ts
+++ b/src/lib/ab-test.ts
@@ -19,7 +19,7 @@
 import { createLogger } from '@/lib/logger';
 import { EnvLoader } from '@/lib/config/environment';
 import { generateSecureId } from '@/lib/utils';
-import { simpleHash } from '@/lib/security/crypto';
+import { simpleHash, secureRandom } from '@/lib/security/crypto';
 
 /**
  * Experiment variant definition
@@ -175,7 +175,7 @@ function saveAssignments(assignments: Record<string, ABAssignment>): void {
  */
 function getDeterministicRandom(experimentId: string): number {
   if (typeof window === 'undefined') {
-    return Math.random();
+    return secureRandom();
   }
 
   try {
@@ -197,7 +197,7 @@ function getDeterministicRandom(experimentId: string): number {
     // Return normalized value 0-1 (0xFFFFFFFF is the max 32-bit unsigned value)
     return hashInt / 4294967295;
   } catch {
-    return Math.random();
+    return secureRandom();
   }
 }
 

--- a/src/lib/pii-redaction.ts
+++ b/src/lib/pii-redaction.ts
@@ -137,10 +137,10 @@ export function redactPII(text: string): string {
 /**
  * Combined regex for sensitive field detection to avoid iterating through an array
  * SECURITY: Includes common sensitive fields like CVV, CVC, PIN to prevent accidental logging.
- * Updated: Added IBAN, SWIFT/BIC, Tax ID, NINO, License patterns (Issue #1171).
+ * Updated: Added IBAN, SWIFT/BIC, Tax ID, NINO, License patterns, Passport, Routing Number (Issue #1171).
  */
 const SENSITIVE_FIELD_REGEX =
-  /api[-_ ]?key|apikey|secret|token|password|passphrase|credential|auth|authorization|access[-_ ]?key|bearer|session[_-]?id|cookie|set-cookie|xsrf-token|csrf-token|private[_-]?key|secret[_-]?key|connection[_-]?string|email|phone|ssn|credit[_-]?card|ip[_-]?address|admin[-_ ]?key|adminkey|cvv|cvc|pin|stack|signature|salt|hmac|webhook|oauth|cert|pwd|iban|swift|bic|tax[-_]?id|nino|ni[-_]?num|license|licence/i;
+  /api[-_ ]?key|apikey|secret|token|password|passphrase|credential|auth|authorization|access[-_ ]?key|bearer|session[_-]?id|cookie|set-cookie|xsrf-token|csrf-token|private[_-]?key|secret[_-]?key|connection[_-]?string|email|phone|ssn|credit[_-]?card|ip[_-]?address|admin[-_ ]?key|adminkey|cvv|cvc|pin|stack|signature|salt|hmac|webhook|oauth|cert|pwd|iban|swift|bic|tax[-_]?id|nino|ni[-_]?num|license|licence|passport|routing[-_ ]?number/i;
 
 const SAFE_FIELDS_SET = new Set<string>(
   PII_REDACTION_CONFIG.SAFE_FIELDS.map((f) => f.toLowerCase())


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Insecure random number generation in A/B test fallbacks and incomplete PII redaction coverage.
🎯 Impact: Predictable A/B test variant assignment if fallbacks are triggered and potential leakage of sensitive fields like passport or routing numbers in logs.
🔧 Fix: Replaced `Math.random()` with `secureRandom()` in `ab-test.ts` and added `passport`/`routing_number` patterns to `pii-redaction.ts`.
✅ Verification: `pnpm test` passed and `pnpm security:check` verified.

---
*PR created automatically by Jules for task [6178058037901760837](https://jules.google.com/task/6178058037901760837) started by @cpa03*