### PR TITLE
🛡️ Sentinel: Harden suspicious request pattern detection

### DIFF
--- a/src/lib/security/suspicious-patterns.ts
+++ b/src/lib/security/suspicious-patterns.ts
@@ -45,13 +45,6 @@ export type SuspiciousPatternCategory =
   | 'prototype_pollution'
   | 'log_injection';
 
-
-
-
-
-
-
-
 /**
  * Details about a detected suspicious pattern
  */
@@ -121,6 +114,11 @@ const SUSPICIOUS_PATTERNS: Record<
       severity: 3,
       description: 'SQL system schema access',
     },
+    {
+      pattern: /\b(extractvalue|updatexml|pg_sleep|sleep)\s*\(/is,
+      severity: 3,
+      description: 'SQL injection function (error/time-based)',
+    },
     // Medium severity
     {
       pattern: /('\s*(or|and)\s+')/is,
@@ -158,7 +156,8 @@ const SUSPICIOUS_PATTERNS: Record<
       description: 'JavaScript protocol',
     },
     {
-      pattern: /on(load|error|click|mouse|focus|blur|key|submit|change|scroll)\s*=/gi,
+      pattern:
+        /on(load|error|click|mouse|focus|blur|key|submit|change|scroll)\s*=/gi,
       severity: 3,
       description: 'Event handler injection',
     },
@@ -228,6 +227,11 @@ const SUSPICIOUS_PATTERNS: Record<
       severity: 3,
       description: 'System file access attempt',
     },
+    {
+      pattern: /C:\\(Windows|winnt|boot\.ini|inetpub)/i,
+      severity: 3,
+      description: 'Windows sensitive file access attempt',
+    },
     // Medium severity
     {
       pattern: /\.\.[\/\\]/,
@@ -249,12 +253,19 @@ const SUSPICIOUS_PATTERNS: Record<
   command_injection: [
     // High severity
     {
-      pattern: /(?:[;&|`]\s*|\b)(rm|del|format|fdisk|shutdown|reboot|halt|init|env|printenv)\b/i,
+      pattern:
+        /(?:[;&|`]\s*|\b)(rm|del|format|fdisk|shutdown|reboot|halt|init|env|printenv)\b/i,
       severity: 3,
       description: 'Destructive or sensitive command injection',
     },
     {
-      pattern: /\bprocess\.(?:exit|env|mainModule|global|cwd|memoryUsage|version)\b/,
+      pattern: /[;&|`]\s*(whoami|id|hostname|uname)\b/i,
+      severity: 3,
+      description: 'Reconnaissance command injection',
+    },
+    {
+      pattern:
+        /\bprocess\.(?:exit|env|mainModule|global|cwd|memoryUsage|version)\b/,
       severity: 3,
       description: 'Node.js process object injection',
     },
@@ -269,7 +280,8 @@ const SUSPICIOUS_PATTERNS: Record<
       description: 'Backtick command execution',
     },
     {
-      pattern: /\$\{IFS\}|(?:\/usr\/bin\/)?(?:nc|netcat|ncat|bash|python|perl|php|ruby|lua)\s+-e\s+['"]?\/bin\/(?:ba)?sh['"]?/i,
+      pattern:
+        /\$\{IFS\}|(?:\/usr\/bin\/)?(?:nc|netcat|ncat|bash|python|perl|php|ruby|lua)\s+-e\s+['"]?\/bin\/(?:ba)?sh['"]?/i,
       severity: 3,
       description: 'Shell bypass or reverse shell execution',
     },
@@ -308,6 +320,11 @@ const SUSPICIOUS_PATTERNS: Record<
       pattern: /(169\.254\.169\.254|metadata\.google)/i,
       severity: 3,
       description: 'Cloud metadata access attempt',
+    },
+    {
+      pattern: /(metadata\.google\.internal|instance-data|169\.254\.)/i,
+      severity: 3,
+      description: 'Expanded cloud metadata or link-local access attempt',
     },
     {
       pattern: /internal\.(service|api|host)/i,
@@ -397,7 +414,8 @@ const SUSPICIOUS_PATTERNS: Record<
       description: 'MongoDB $where injection',
     },
     {
-      pattern: /\$(gt|gte|lt|lte|ne|eq|in|nin|exists|type|mod|regex|text|all|elemMatch|size)\s*:/i,
+      pattern:
+        /\$(gt|gte|lt|lte|ne|eq|in|nin|exists|type|mod|regex|text|all|elemMatch|size)\s*:/i,
       severity: 2,
       description: 'MongoDB operator injection',
     },
@@ -637,19 +655,6 @@ export function detectSuspiciousPatterns(
     logger.warn('Body scanning requested but not yet implemented');
   }
 
-
-
-
-
-
-
-
-
-
-
-
-
-
   // Scan headers safely - handle cases where headers.entries() might not exist (test mocks)
   try {
     if (typeof request.headers.entries === 'function') {
@@ -663,11 +668,6 @@ export function detectSuspiciousPatterns(
   } catch {
     // Headers iteration failed - continue without header scanning
   }
-
-
-
-
-
 
   // PERFORMANCE: patterns are already pre-filtered by scanString.
   // We only need to calculate maxSeverity from the findings.

--- a/test-regex-2.js
+++ b/test-regex-2.js
@@ -1,0 +1,8 @@
+const regex = /[;&|`]\s*(whoami|id|hostname|uname)\b/i;
+const payloads = [
+  "test ; whoami",
+  "test | id",
+  "test & hostname",
+  "test`uname`"
+];
+payloads.forEach(p => console.log(p, "=>", regex.test(p)));

--- a/test-regex-3.js
+++ b/test-regex-3.js
@@ -1,0 +1,7 @@
+const regex = /[;&|`]\s*(whoami|id|hostname|uname)\b/i;
+const sep = '&';
+const cmd = 'whoami';
+const payload = "test " + sep + " " + cmd;
+console.log("Payload:", payload);
+console.log("Encoded:", encodeURIComponent(payload));
+console.log("Result:", regex.test(payload));

--- a/test-regex-4.js
+++ b/test-regex-4.js
@@ -1,0 +1,12 @@
+const regex = /[;&|`]\s*(whoami|id|hostname|uname)\b/i;
+const separators = [';', '|', '&', '`'];
+const commands = ['whoami', 'id', 'hostname', 'uname'];
+for (const cmd of commands) {
+  for (const sep of separators) {
+    const payload = sep === '`' ? "test" + sep + cmd + sep : "test " + sep + " " + cmd;
+    const url = "https://example.com/api/test?cmd=" + payload;
+    const urlObj = new URL(url);
+    const value = urlObj.searchParams.get('cmd');
+    console.log(payload, "->", value, "->", regex.test(value));
+  }
+}

--- a/test-regex.js
+++ b/test-regex.js
@@ -1,0 +1,4 @@
+const regex = /[;&|`]\s*(whoami|id|hostname|uname)\b/i;
+console.log(";whoami", regex.test(";whoami"));
+console.log("test ; whoami", regex.test("test ; whoami"));
+console.log("whoami", regex.test("whoami"));

--- a/tests/security/suspicious-patterns.test.ts
+++ b/tests/security/suspicious-patterns.test.ts
@@ -7,7 +7,10 @@ import { NextRequest } from 'next/server';
 import { detectSuspiciousPatterns } from '@/lib/security/suspicious-patterns';
 
 describe('Suspicious Pattern Detection Improvements', () => {
-  const createMockRequest = (url: string, headers: Record<string, string> = {}) => {
+  const createMockRequest = (
+    url: string,
+    headers: Record<string, string> = {}
+  ) => {
     return new NextRequest(new URL(url, 'https://example.com'), {
       headers: new Headers(headers),
     });
@@ -15,52 +18,161 @@ describe('Suspicious Pattern Detection Improvements', () => {
 
   describe('SQL Injection', () => {
     it('should detect string-based tautologies without numbers', () => {
-      const request = createMockRequest("https://example.com/api/test?id=' OR 'a'='a");
+      const request = createMockRequest(
+        "https://example.com/api/test?id=' OR 'a'='a"
+      );
       const result = detectSuspiciousPatterns(request, { minSeverity: 1 });
       expect(result.detected).toBe(true);
-      expect(result.patterns.some(p => p.category === 'sql_injection')).toBe(true);
+      expect(result.patterns.some((p) => p.category === 'sql_injection')).toBe(
+        true
+      );
     });
 
     it('should detect system table access attempts even without keywords', () => {
       // Current patterns might miss this if they only look for SELECT ... FROM
-      const request = createMockRequest('https://example.com/api/test?table=information_schema.columns');
+      const request = createMockRequest(
+        'https://example.com/api/test?table=information_schema.columns'
+      );
       const result = detectSuspiciousPatterns(request, { minSeverity: 1 });
       expect(result.detected).toBe(true);
-      expect(result.patterns.some(p => p.category === 'sql_injection')).toBe(true);
+      expect(result.patterns.some((p) => p.category === 'sql_injection')).toBe(
+        true
+      );
     });
   });
 
   describe('XSS', () => {
     it('should detect srcdoc attribute injection', () => {
       // Existing patterns might miss srcdoc if it doesn't contain <script>
-      const request = createMockRequest('https://example.com/api/test?attr=<div srcdoc="onclick=alert(1)">');
+      const request = createMockRequest(
+        'https://example.com/api/test?attr=<div srcdoc="onclick=alert(1)">'
+      );
       const result = detectSuspiciousPatterns(request, { minSeverity: 1 });
       expect(result.detected).toBe(true);
-      expect(result.patterns.some(p => p.category === 'xss')).toBe(true);
+      expect(result.patterns.some((p) => p.category === 'xss')).toBe(true);
     });
 
     it('should detect vbscript: protocol', () => {
-      const requestVb = createMockRequest('https://example.com/api/test?url=vbscript:msgbox("hello")');
+      const requestVb = createMockRequest(
+        'https://example.com/api/test?url=vbscript:msgbox("hello")'
+      );
       const result = detectSuspiciousPatterns(requestVb, { minSeverity: 1 });
       expect(result.detected).toBe(true);
-      expect(result.patterns.some(p => p.category === 'xss')).toBe(true);
+      expect(result.patterns.some((p) => p.category === 'xss')).toBe(true);
     });
   });
 
   describe('Command Injection', () => {
     it('should detect environment variable dumping (env/printenv)', () => {
       // Existing patterns miss env/printenv
-      const requestEnv = createMockRequest('https://example.com/api/test?cmd=printenv');
+      const requestEnv = createMockRequest(
+        'https://example.com/api/test?cmd=printenv'
+      );
       const result = detectSuspiciousPatterns(requestEnv, { minSeverity: 1 });
       expect(result.detected).toBe(true);
-      expect(result.patterns.some(p => p.category === 'command_injection')).toBe(true);
+      expect(
+        result.patterns.some((p) => p.category === 'command_injection')
+      ).toBe(true);
     });
 
     it('should detect Node.js specific injection attempts', () => {
-      const request = createMockRequest('https://example.com/api/test?code=process.version');
+      const request = createMockRequest(
+        'https://example.com/api/test?code=process.version'
+      );
       const result = detectSuspiciousPatterns(request, { minSeverity: 1 });
       expect(result.detected).toBe(true);
-      expect(result.patterns.some(p => p.category === 'command_injection')).toBe(true);
+      expect(
+        result.patterns.some((p) => p.category === 'command_injection')
+      ).toBe(true);
+    });
+
+    it('should detect reconnaissance commands with separators', () => {
+      const commands = ['whoami', 'id', 'hostname', 'uname'];
+      for (const cmd of commands) {
+        // Test with different separators
+        // Note: & is excluded from unencoded URL testing because URL search params
+        // would split it into multiple parameters.
+        const separators = [';', '|', '`'];
+        for (const sep of separators) {
+          const payload =
+            sep === '`' ? `test${sep}${cmd}${sep}` : `test ${sep} ${cmd}`;
+          const request = createMockRequest(
+            `https://example.com/api/test?cmd=${payload}`
+          );
+          const result = detectSuspiciousPatterns(request, { minSeverity: 3 });
+          expect(result.detected).toBe(true);
+          expect(result.maxSeverity).toBe(3);
+          expect(
+            result.patterns.some((p) => p.category === 'command_injection')
+          ).toBe(true);
+        }
+      }
+    });
+
+    it('should NOT detect standalone reconnaissance commands as parameters', () => {
+      const commands = ['whoami', 'id', 'hostname', 'uname'];
+      for (const cmd of commands) {
+        const request = createMockRequest(
+          `https://example.com/api/test?${cmd}=test-value`
+        );
+        const result = detectSuspiciousPatterns(request, { minSeverity: 3 });
+        // Should not be detected at severity 3
+        expect(result.detected).toBe(false);
+      }
+    });
+  });
+
+  describe('New Enhanced Patterns', () => {
+    it('should detect error/time-based SQL functions', () => {
+      const functions = ['extractvalue', 'updatexml', 'pg_sleep', 'sleep'];
+      for (const fn of functions) {
+        const request = createMockRequest(
+          `https://example.com/api/test?q=${fn}(1)`
+        );
+        const result = detectSuspiciousPatterns(request, { minSeverity: 3 });
+        expect(result.detected).toBe(true);
+        expect(result.maxSeverity).toBe(3);
+        expect(
+          result.patterns.some((p) => p.category === 'sql_injection')
+        ).toBe(true);
+      }
+    });
+
+    it('should detect Windows sensitive paths', () => {
+      const paths = [
+        'C:\\Windows\\System32',
+        'C:\\winnt\\system32',
+        'C:\\boot.ini',
+        'C:\\inetpub\\wwwroot',
+      ];
+      for (const path of paths) {
+        const request = createMockRequest(
+          `https://example.com/api/test?file=${path}`
+        );
+        const result = detectSuspiciousPatterns(request, { minSeverity: 3 });
+        expect(result.detected).toBe(true);
+        expect(result.maxSeverity).toBe(3);
+        expect(
+          result.patterns.some((p) => p.category === 'path_traversal')
+        ).toBe(true);
+      }
+    });
+
+    it('should detect expanded SSRF cloud metadata and link-local access', () => {
+      const targets = [
+        'metadata.google.internal',
+        'instance-data',
+        '169.254.1.1',
+      ];
+      for (const target of targets) {
+        const request = createMockRequest(
+          `https://example.com/api/test?url=http://${target}`
+        );
+        const result = detectSuspiciousPatterns(request, { minSeverity: 3 });
+        expect(result.detected).toBe(true);
+        expect(result.maxSeverity).toBe(3);
+        expect(result.patterns.some((p) => p.category === 'ssrf')).toBe(true);
+      }
     });
   });
 });


### PR DESCRIPTION
🛡️ Sentinel: Harden suspicious request pattern detection

This PR enhances the application's defense-in-depth by hardening the `detectSuspiciousPatterns` utility in `src/lib/security/suspicious-patterns.ts`. 

Key enhancements:
- **SQL Injection**: Added detection for error-based functions (`extractvalue`, `updatexml`) and expanded time-based detection (`pg_sleep`, `sleep`).
- **Path Traversal**: Added heuristics for Windows-specific sensitive files and directories (`C:\Windows`, `boot.ini`, etc.).
- **Command Injection**: Added detection for common reconnaissance commands (`whoami`, `id`, `hostname`, `uname`). These patterns strictly require a shell separator prefix (`[;&|\`]`) to avoid false positives on common query parameters like `id`.
- **SSRF**: Expanded cloud metadata detection to include Google Cloud and general `instance-data` patterns, along with the full `169.254.` link-local range.

Verification:
- Added 5 new test cases to `tests/security/suspicious-patterns.test.ts` covering both positive detection and negative (false positive prevention) scenarios.
- Ran `pnpm lint`, `pnpm test`, and `npm run security:check` to ensure correctness and zero regressions.
- Verified that standalone parameters like `?id=123` are no longer flagged at high severity.

---
*PR created automatically by Jules for task [11622985616832172804](https://jules.google.com/task/11622985616832172804) started by @cpa03*