### PR TITLE
🎨 Palette: Restore keyboard focus after scroll-to-top

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -179,7 +179,12 @@ export default async function RootLayout({
                   </div>
                 </div>
               </header>
-              <main id="main-content" className="flex-1" role="main">
+              <main
+                id="main-content"
+                className="flex-1 focus:outline-none"
+                role="main"
+                tabIndex={-1}
+              >
                 {children}
               </main>
               <footer className="bg-white border-t border-gray-200">

--- a/src/components/ScrollToTop.tsx
+++ b/src/components/ScrollToTop.tsx
@@ -93,6 +93,13 @@ function ScrollToTopComponent({
         behavior: smooth ? 'smooth' : 'auto',
       });
     }
+
+    // A11y Pattern: Restore keyboard focus to main content after scroll to top (Issue #942)
+    // This prevents keyboard users from being "lost" at the bottom of the document
+    const mainContent = document.getElementById('main-content');
+    if (mainContent) {
+      mainContent.focus({ preventScroll: true });
+    }
   }, [smooth, prefersReducedMotion]);
 
   const handleKeyDown = useCallback(


### PR DESCRIPTION
This change implements a micro-UX improvement for keyboard accessibility. When a user clicks the "Scroll to Top" button (especially via keyboard), the focus is now programmatically shifted to the `<main id="main-content">` element. This prevents the keyboard focus from being stranded at the bottom of the page, which would otherwise force the user to tab through the entire page again to reach the top content.

Key changes:
1.  **Layout**: Prepared the main content area for programmatic focus by adding `tabIndex={-1}` and `focus:outline-none`.
2.  **ScrollToTop Component**: Updated the `scrollToTop` logic to target the main content after the scroll is initiated.
3.  **Documentation**: Logged this discovery in the Palette journal for future reference.

Accessibility verified via Axe and manual Playwright testing.

---
*PR created automatically by Jules for task [3204177938585929321](https://jules.google.com/task/3204177938585929321) started by @cpa03*