### PR TITLE
🎨 Palette: Consistent Status Announcements for A11y

### DIFF
--- a/src/components/CopyButton.tsx
+++ b/src/components/CopyButton.tsx
@@ -6,6 +6,7 @@ import { UI_CONFIG } from '@/lib/config/constants';
 import { ToastOptions } from '@/components/ToastContainer';
 import { triggerHapticFeedback } from '@/lib/utils';
 import Tooltip from './Tooltip';
+import StatusAnnouncer from './StatusAnnouncer';
 
 export interface CopyButtonProps {
   textToCopy: string;
@@ -117,64 +118,71 @@ const CopyButtonComponent = function CopyButton({
   };
 
   return (
-    <Tooltip
-      content={copied ? successLabel : ariaLabel}
-      disabled={false}
-      position="top"
-    >
-      <button
-        onClick={handleCopy}
-        className={`${baseClasses} ${variantClasses[variant]} ${className}`}
-        aria-label={copied ? 'Copied to clipboard' : ariaLabel}
-        type="button"
+    <>
+      <StatusAnnouncer
+        message={successLabel}
+        politeness="polite"
+        triggered={copied}
+      />
+      <Tooltip
+        content={copied ? successLabel : ariaLabel}
+        disabled={false}
+        position="top"
       >
-        <span className="relative flex items-center justify-center w-4 h-4">
-          <svg
-            className={`
-              absolute inset-0 w-4 h-4 transition-all duration-200
-              ${copied ? 'opacity-0 scale-75' : 'opacity-100 scale-100'}
-            `}
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-            strokeWidth={2}
-            aria-hidden="true"
-          >
-            <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
-            <path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1" />
-          </svg>
+        <button
+          onClick={handleCopy}
+          className={`${baseClasses} ${variantClasses[variant]} ${className}`}
+          aria-label={copied ? 'Copied to clipboard' : ariaLabel}
+          type="button"
+        >
+          <span className="relative flex items-center justify-center w-4 h-4">
+            <svg
+              className={`
+                absolute inset-0 w-4 h-4 transition-all duration-200
+                ${copied ? 'opacity-0 scale-75' : 'opacity-100 scale-100'}
+              `}
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+              aria-hidden="true"
+            >
+              <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+              <path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1" />
+            </svg>
 
-          <svg
-            className={`
-              absolute inset-0 w-4 h-4 text-green-600 transition-all duration-200
-              ${copied ? 'opacity-100 scale-100' : 'opacity-0 scale-50'}
-            `}
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-            strokeWidth={3}
-            aria-hidden="true"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              d="M5 13l4 4L19 7"
-            />
-          </svg>
-        </span>
-
-        {variant !== 'icon-only' && (
-          <span
-            className={`
-              transition-all duration-200
-              ${copied ? 'text-green-700' : ''}
-            `}
-          >
-            {copied ? successLabel : label}
+            <svg
+              className={`
+                absolute inset-0 w-4 h-4 text-green-600 transition-all duration-200
+                ${copied ? 'opacity-100 scale-100' : 'opacity-0 scale-50'}
+              `}
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={3}
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M5 13l4 4L19 7"
+              />
+            </svg>
           </span>
-        )}
-      </button>
-    </Tooltip>
+
+          {variant !== 'icon-only' && (
+            <span
+              className={`
+                transition-all duration-200
+                ${copied ? 'text-green-700' : ''}
+              `}
+            >
+              {copied ? successLabel : label}
+            </span>
+          )}
+        </button>
+      </Tooltip>
+    </>
   );
 };
 

--- a/src/components/ShareButton.tsx
+++ b/src/components/ShareButton.tsx
@@ -7,6 +7,7 @@ import { APP_CONFIG } from '@/lib/config';
 import { ToastOptions } from '@/components/ToastContainer';
 import { triggerHapticFeedback } from '@/lib/utils';
 import Tooltip from './Tooltip';
+import StatusAnnouncer from './StatusAnnouncer';
 
 export interface ShareButtonProps {
   shareUrl?: string;
@@ -170,71 +171,76 @@ const ShareButtonComponent = function ShareButton({
   };
 
   return (
-    <Tooltip
-      content={shared ? successLabel : ariaLabel}
-      disabled={false}
-      position="top"
-    >
-      <button
-        onClick={handleShare}
-        className={`${baseClasses} ${variantClasses[variant]} ${className}`}
-        aria-label={shared ? 'Shared' : ariaLabel}
-        aria-live="polite"
-        aria-atomic="true"
-        type="button"
+    <>
+      <StatusAnnouncer
+        message={successLabel}
+        politeness="polite"
+        triggered={shared}
+      />
+      <Tooltip
+        content={shared ? successLabel : ariaLabel}
+        disabled={false}
+        position="top"
       >
-        <span className="relative flex items-center justify-center w-4 h-4">
-          {/* Share icon */}
-          <svg
-            className={`
-              absolute inset-0 w-4 h-4 transition-all duration-200
-              ${shared ? 'opacity-0 scale-75' : 'opacity-100 scale-100'}
-            `}
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-            strokeWidth={2}
-            aria-hidden="true"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.368 2.684 3 3 0 00-5.368-2.684z"
-            />
-          </svg>
+        <button
+          onClick={handleShare}
+          className={`${baseClasses} ${variantClasses[variant]} ${className}`}
+          aria-label={shared ? 'Shared' : ariaLabel}
+          type="button"
+        >
+          <span className="relative flex items-center justify-center w-4 h-4">
+            {/* Share icon */}
+            <svg
+              className={`
+                absolute inset-0 w-4 h-4 transition-all duration-200
+                ${shared ? 'opacity-0 scale-75' : 'opacity-100 scale-100'}
+              `}
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.368 2.684 3 3 0 00-5.368-2.684z"
+              />
+            </svg>
 
-          {/* Checkmark icon when shared */}
-          <svg
-            className={`
-              absolute inset-0 w-4 h-4 text-green-500 transition-all duration-200
-              ${shared ? 'opacity-100 scale-100' : 'opacity-0 scale-50'}
-            `}
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-            strokeWidth={3}
-            aria-hidden="true"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              d="M5 13l4 4L19 7"
-            />
-          </svg>
-        </span>
-
-        {variant !== 'icon-only' && (
-          <span
-            className={`
-              transition-all duration-200
-              ${shared ? 'text-green-400' : ''}
-            `}
-          >
-            {shared ? successLabel : label}
+            {/* Checkmark icon when shared */}
+            <svg
+              className={`
+                absolute inset-0 w-4 h-4 text-green-500 transition-all duration-200
+                ${shared ? 'opacity-100 scale-100' : 'opacity-0 scale-50'}
+              `}
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={3}
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M5 13l4 4L19 7"
+              />
+            </svg>
           </span>
-        )}
-      </button>
-    </Tooltip>
+
+          {variant !== 'icon-only' && (
+            <span
+              className={`
+                transition-all duration-200
+                ${shared ? 'text-green-400' : ''}
+              `}
+            >
+              {shared ? successLabel : label}
+            </span>
+          )}
+        </button>
+      </Tooltip>
+    </>
   );
 };
 

--- a/src/components/StatusAnnouncer.tsx
+++ b/src/components/StatusAnnouncer.tsx
@@ -25,7 +25,12 @@ function StatusAnnouncerComponent({
       clearTimeout(timeoutRef.current);
     }
 
-    if (triggered && message && message !== previousMessageRef.current) {
+    if (!triggered) {
+      previousMessageRef.current = '';
+      return;
+    }
+
+    if (message && message !== previousMessageRef.current) {
       timeoutRef.current = setTimeout(() => {
         const announcer = announcerRef.current;
         if (announcer) {


### PR DESCRIPTION
This PR implements a micro-UX improvement for accessibility by ensuring consistent status announcements for transient success states.

### 💡 What: The UX enhancement added
Integrated the `StatusAnnouncer` component into `CopyButton` and `ShareButton`. This component uses a hidden `aria-live` region to announce success messages like "Copied!" or "Shared!" when the user interacts with these buttons.

### 🎯 Why: The user problem it solves
Screen readers often miss transient state changes (like changing a button's `aria-label` while it's focused) or might provide inconsistent feedback depending on the specific assistive technology. A dedicated `StatusAnnouncer` is a more robust pattern for ensuring these "micro-feedback" moments are heard by all users.

### ♿ Accessibility: Any a11y improvements made
- Guaranteed announcement of success states for copy and share actions.
- Cleaned up redundant `aria-live` attributes on interactive elements to prevent "chattiness" or duplicate announcements.
- Maintained existing `aria-label` updates as a secondary visual/aural cue.

### ✅ Verification
- Ran `pnpm lint`, `pnpm test`, and `pnpm build` successfully.
- Verified DOM updates with a Playwright script that confirmed the announcer was correctly populated upon interaction.
- Documented this reusable pattern in the Palette journal.

---
*PR created automatically by Jules for task [14714668456005261092](https://jules.google.com/task/14714668456005261092) started by @cpa03*