### PR TITLE
🎨 Palette: Standardize accessibility feedback and button types

### DIFF
--- a/src/components/CopyButton.tsx
+++ b/src/components/CopyButton.tsx
@@ -6,6 +6,7 @@ import { UI_CONFIG } from '@/lib/config/constants';
 import { ToastOptions } from '@/components/ToastContainer';
 import { triggerHapticFeedback } from '@/lib/utils';
 import Tooltip from './Tooltip';
+import StatusAnnouncer from './StatusAnnouncer';
 
 export interface CopyButtonProps {
   textToCopy: string;
@@ -120,17 +121,19 @@ const CopyButtonComponent = function CopyButton({
   const glowClass = copied ? 'animate-copy-success-glow' : '';
 
   return (
-    <Tooltip
-      content={copied ? successLabel : ariaLabel}
-      disabled={false}
-      position="top"
-    >
-      <button
-        onClick={handleCopy}
-        className={`${baseClasses} ${variantClasses[variant]} ${glowClass} ${className}`}
-        aria-label={copied ? 'Copied to clipboard' : ariaLabel}
-        type="button"
+    <>
+      <StatusAnnouncer message={successLabel} triggered={copied} />
+      <Tooltip
+        content={copied ? successLabel : ariaLabel}
+        disabled={false}
+        position="top"
       >
+        <button
+          onClick={handleCopy}
+          className={`${baseClasses} ${variantClasses[variant]} ${glowClass} ${className}`}
+          aria-label={ariaLabel}
+          type="button"
+        >
         <span className="relative flex items-center justify-center w-4 h-4">
           <svg
             className={`
@@ -176,8 +179,9 @@ const CopyButtonComponent = function CopyButton({
             {copied ? successLabel : label}
           </span>
         )}
-      </button>
-    </Tooltip>
+        </button>
+      </Tooltip>
+    </>
   );
 };
 

--- a/src/components/NotificationPrompt.tsx
+++ b/src/components/NotificationPrompt.tsx
@@ -129,6 +129,7 @@ export default function NotificationPrompt({
           <button
             onClick={handleEnable}
             disabled={isRequesting}
+            type="button"
             className={`
               px-3 py-1.5 text-sm font-medium rounded-md transition-all duration-200
               bg-primary-600 text-white hover:bg-primary-700
@@ -170,6 +171,7 @@ export default function NotificationPrompt({
           {dismissible && (
             <button
               onClick={handleDismiss}
+              type="button"
               className="p-1 text-primary-400 hover:text-primary-600 transition-colors rounded"
               aria-label="Dismiss notification prompt"
             >
@@ -236,6 +238,7 @@ export default function NotificationPrompt({
             <button
               onClick={handleEnable}
               disabled={isRequesting}
+              type="button"
               className={`
                 inline-flex items-center justify-center gap-2 px-4 py-2
                 text-sm font-medium rounded-lg transition-all duration-200
@@ -245,6 +248,7 @@ export default function NotificationPrompt({
                 disabled:opacity-50 disabled:cursor-not-allowed
                 active:scale-[0.98]
               `}
+              aria-label={enableLabel}
             >
               {isRequesting ? (
                 <>
@@ -294,7 +298,9 @@ export default function NotificationPrompt({
             {dismissible && (
               <button
                 onClick={handleDismiss}
+                type="button"
                 className="text-sm text-primary-600 hover:text-primary-800 font-medium transition-colors"
+                aria-label="Maybe later"
               >
                 Maybe later
               </button>

--- a/src/components/ShareButton.tsx
+++ b/src/components/ShareButton.tsx
@@ -7,6 +7,7 @@ import { APP_CONFIG } from '@/lib/config';
 import { ToastOptions } from '@/components/ToastContainer';
 import { triggerHapticFeedback } from '@/lib/utils';
 import Tooltip from './Tooltip';
+import StatusAnnouncer from './StatusAnnouncer';
 
 export interface ShareButtonProps {
   shareUrl?: string;
@@ -170,19 +171,19 @@ const ShareButtonComponent = function ShareButton({
   };
 
   return (
-    <Tooltip
-      content={shared ? successLabel : ariaLabel}
-      disabled={false}
-      position="top"
-    >
-      <button
-        onClick={handleShare}
-        className={`${baseClasses} ${variantClasses[variant]} ${className}`}
-        aria-label={shared ? 'Shared' : ariaLabel}
-        aria-live="polite"
-        aria-atomic="true"
-        type="button"
+    <>
+      <StatusAnnouncer message={toastMessage} triggered={shared} />
+      <Tooltip
+        content={shared ? successLabel : ariaLabel}
+        disabled={false}
+        position="top"
       >
+        <button
+          onClick={handleShare}
+          className={`${baseClasses} ${variantClasses[variant]} ${className}`}
+          aria-label={ariaLabel}
+          type="button"
+        >
         <span className="relative flex items-center justify-center w-4 h-4">
           {/* Share icon */}
           <svg
@@ -233,8 +234,9 @@ const ShareButtonComponent = function ShareButton({
             {shared ? successLabel : label}
           </span>
         )}
-      </button>
-    </Tooltip>
+        </button>
+      </Tooltip>
+    </>
   );
 };
 


### PR DESCRIPTION
This PR implements a set of micro-UX improvements focused on accessibility and standardizing interaction patterns:

1. **Standardized Accessibility Feedback**: In `CopyButton` and `ShareButton`, success states (like "Copied!" or "Shared!") were previously announced by changing the `aria-label`. This can lead to double-announcements or unreliable feedback in some screen readers. I've integrated the `StatusAnnouncer` component (which uses `aria-live`) to handle these transient announcements, while keeping the `aria-label` static for persistent context.
2. **Explicit Button Types**: Added `type="button"` to buttons in `NotificationPrompt`. This is a defensive coding practice that prevents buttons from accidentally submitting forms if they are ever nested within a `<form>` element.
3. **Improved ARIA Labels**: Added descriptive `aria-label` attributes to the "Enable" and "Maybe later" buttons in the `NotificationPrompt` component.

All changes were verified using the project's accessibility test suite (`pnpm test tests/accessibility.test.tsx`) and manual inspection of the DOM and ARIA attributes in a local development environment.

---
*PR created automatically by Jules for task [15221951200858583327](https://jules.google.com/task/15221951200858583327) started by @cpa03*