### PR TITLE
🛡️ Sentinel: Harden generateId fallback with secureRandom

### DIFF
--- a/src/lib/security/crypto.ts
+++ b/src/lib/security/crypto.ts
@@ -50,8 +50,9 @@ export function generateId(): string {
 
   // 3. Last resort fallback (non-cryptographic)
   // This should only be reached in extremely restricted legacy environments
+  // We use secureRandom() which provides a centralized fallback with security logging
   const timestamp = Date.now().toString(36);
-  const randomPart = Math.random().toString(36).substring(2, 11);
+  const randomPart = secureRandom().toString(36).substring(2, 11);
   return `${timestamp}-${randomPart}`;
 }
 

--- a/tests/security/crypto-fallback.test.ts
+++ b/tests/security/crypto-fallback.test.ts
@@ -1,0 +1,37 @@
+import { generateId, secureRandom } from '@/lib/security/crypto';
+
+describe('generateId Fallback', () => {
+  let originalCrypto: any;
+  let warnSpy: jest.SpyInstance;
+
+  beforeAll(() => {
+    originalCrypto = globalThis.crypto;
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterAll(() => {
+    Object.defineProperty(globalThis, 'crypto', {
+      value: originalCrypto,
+      configurable: true,
+    });
+    warnSpy.mockRestore();
+  });
+
+  it('should use secureRandom() fallback and log warning when crypto is unavailable', () => {
+    // Force fallback by making crypto undefined
+    Object.defineProperty(globalThis, 'crypto', {
+      value: undefined,
+      configurable: true,
+    });
+
+    const id = generateId();
+
+    expect(id).toBeDefined();
+    expect(typeof id).toBe('string');
+    expect(id.includes('-')).toBe(true);
+    // Should have logged a warning from secureRandom()
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('CRITICAL SECURITY WARNING: Using insecure random generator')
+    );
+  });
+});


### PR DESCRIPTION
This PR hardens the `generateId` utility by ensuring it uses the centralized `secureRandom()` fallback instead of `Math.random()` when the Web Crypto API is unavailable. This maintains consistent security logging and follows defense-in-depth principles.

---
*PR created automatically by Jules for task [8736627972862930089](https://jules.google.com/task/8736627972862930089) started by @cpa03*