### PR TITLE
🛡️ Sentinel: Standardize CSP violation logging

### DIFF
--- a/src/app/api/csp-report/route.ts
+++ b/src/app/api/csp-report/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { createLogger } from '@/lib/logger';
 import { withApiHandler, ApiContext } from '@/lib/api-handler';
 import { STATUS_CODES } from '@/lib/config';
+import { SecurityAuditLog } from '@/lib/security/audit-log';
 
 const logger = createLogger('CSPReport');
 
@@ -73,66 +74,32 @@ async function handleCSPReport(context: ApiContext): Promise<Response> {
 
     // Extract violation details from report
     const cspReport = reportData['csp-report'];
-    const documentUri = cspReport['document-uri'] || 'unknown';
-    const blockedUri = cspReport['blocked-uri'] || 'unknown';
+    const documentUri = cspReport['document-uri'];
+    const blockedUri = cspReport['blocked-uri'];
     const violatedDirective = cspReport['violated-directive'] || 'unknown';
-    const effectiveDirective =
-      cspReport['effective-directive'] || violatedDirective;
-    const originalPolicy = cspReport['original-policy'] || '';
-    const referrer = cspReport['referrer'] || '';
-    const sourceFile = cspReport['source-file'] || '';
+    const effectiveDirective = cspReport['effective-directive'];
+    const originalPolicy = cspReport['original-policy'];
+    const referrer = cspReport['referrer'];
+    const sourceFile = cspReport['source-file'];
     const lineNumber = cspReport['line-number'];
     const columnNumber = cspReport['column-number'];
-    const scriptSample = cspReport['script-sample'] || '';
+    const scriptSample = cspReport['script-sample'];
 
-    // Determine severity based on violation type
-    let severity: 'error' | 'warn' | 'info' = 'warn';
-    if (
-      violatedDirective.includes('script-src') &&
-      blockedUri !== 'inline' &&
-      blockedUri !== 'eval'
-    ) {
-      severity = 'error'; // Potential XSS attempt from external source
-    } else if (violatedDirective.includes('default-src')) {
-      severity = 'warn';
-    } else {
-      severity = 'info';
-    }
-
-    // Construct log metadata
-    const logMetadata: Record<string, unknown> = {
-      documentUri,
-      blockedUri,
+    // Log the violation via SecurityAuditLog for standardized handling
+    SecurityAuditLog.logCSPViolation({
       violatedDirective,
       effectiveDirective,
-      referrer: referrer || undefined,
-      userAgent: request.headers.get('user-agent') || 'unknown',
-      timestamp: new Date().toISOString(),
-    };
-
-    // Add source location if available
-    if (sourceFile) {
-      logMetadata.sourceFile = sourceFile;
-      if (lineNumber !== undefined) logMetadata.lineNumber = lineNumber;
-      if (columnNumber !== undefined) logMetadata.columnNumber = columnNumber;
-    }
-
-    // Truncate long values to prevent log flooding
-    if (originalPolicy) {
-      logMetadata.originalPolicy = `${originalPolicy.substring(0, 200)}...`;
-    }
-    if (scriptSample) {
-      logMetadata.scriptSample = `${scriptSample.substring(0, 100)}...`;
-    }
-
-    // Log the violation with appropriate severity
-    if (severity === 'error') {
-      logger.error('CSP Violation - Potential XSS Detected', logMetadata);
-    } else if (severity === 'warn') {
-      logger.warn('CSP Violation Report', logMetadata);
-    } else {
-      logger.info('CSP Violation Report', logMetadata);
-    }
+      blockedUri,
+      sourceFile,
+      lineNumber,
+      columnNumber,
+      originalPolicy,
+      documentUri,
+      referrer,
+      scriptSample,
+      userAgent: request.headers.get('user-agent') || undefined,
+      requestId: context.requestId,
+    });
 
     // Return 204 No Content - browsers don't need a response
     return new NextResponse(null, { status: STATUS_CODES.NO_CONTENT });

--- a/src/lib/security/audit-log.ts
+++ b/src/lib/security/audit-log.ts
@@ -123,6 +123,8 @@ export interface RateLimitEventDetails {
 export interface CSPViolationEventDetails {
   /** Directive that was violated */
   violatedDirective: string;
+  /** Directive that actually failed */
+  effectiveDirective?: string;
   /** URL that caused the violation */
   blockedUri?: string;
   /** Source file if available */
@@ -133,6 +135,14 @@ export interface CSPViolationEventDetails {
   columnNumber?: number;
   /** Original policy */
   originalPolicy?: string;
+  /** URI of the document where violation occurred */
+  documentUri?: string;
+  /** Referrer of the document */
+  referrer?: string;
+  /** Sample of the script that caused violation */
+  scriptSample?: string;
+  /** User Agent of the reporting browser */
+  userAgent?: string;
   /** Request ID for tracing */
   requestId?: string;
 }
@@ -321,7 +331,9 @@ export const SecurityAuditLog = {
     if (
       details.blockedUri &&
       !details.blockedUri.startsWith('/') &&
-      !details.blockedUri.startsWith('inline')
+      !details.blockedUri.startsWith('inline') &&
+      !details.blockedUri.startsWith('data:') &&
+      !details.blockedUri.startsWith('blob:')
     ) {
       severity = severity === 'high' ? 'critical' : 'high';
     }
@@ -338,10 +350,22 @@ export const SecurityAuditLog = {
       requestId: details.requestId,
       metadata: {
         violatedDirective: details.violatedDirective,
+        effectiveDirective:
+          details.effectiveDirective || details.violatedDirective,
         blockedUri: details.blockedUri,
         sourceFile: details.sourceFile,
         lineNumber: details.lineNumber,
         columnNumber: details.columnNumber,
+        documentUri: details.documentUri,
+        referrer: details.referrer,
+        userAgent: details.userAgent,
+        // Truncate long values to prevent log flooding (Bolt optimization)
+        scriptSample: details.scriptSample
+          ? `${details.scriptSample.substring(0, 200)}${details.scriptSample.length > 200 ? '...' : ''}`
+          : undefined,
+        originalPolicy: details.originalPolicy
+          ? `${details.originalPolicy.substring(0, 500)}${details.originalPolicy.length > 500 ? '...' : ''}`
+          : undefined,
       },
       environment: getEnvironment(),
     };


### PR DESCRIPTION
🛡️ Sentinel: [security improvement] Standardize CSP violation logging

This PR enhances the application's security observability by centralizing and standardizing the handling of Content Security Policy (CSP) violation reports.

💡 **Vulnerability/Improvement:** The existing CSP reporting endpoint used direct logging and manual severity classification, leading to inconsistent security audits and missing valuable telemetry data (like User-Agent and Referrer).

🎯 **Impact:** Standardizing these logs via `SecurityAuditLog` ensures that all security-relevant events follow a consistent schema, are properly categorized by severity, and automatically benefit from PII redaction. This significantly improves the ability to monitor for and respond to potential XSS attacks.

🔧 **Fix:**
1.  Updated `SecurityAuditLog` and its `CSPViolationEventDetails` interface to support modern CSP Level 3 report fields.
2.  Implemented safety measures like string truncation for large report payloads to prevent log-based DoS (log flooding).
3.  Refactored the `/api/csp-report` API route to delegate logging to the centralized security audit system.

✅ **Verification:**
- Ran `npm test tests/security/` to ensure all core security utilities and detection patterns remain functional.
- Verified that CSP reports are correctly logged with the enhanced metadata and proper severity levels.

---
*PR created automatically by Jules for task [1302652341255851852](https://jules.google.com/task/1302652341255851852) started by @cpa03*