### PR TITLE
🛡️ Sentinel: Fix [HIGH] Fail-open authentication in metrics endpoint

### DIFF
--- a/src/app/api/metrics/route.ts
+++ b/src/app/api/metrics/route.ts
@@ -3,21 +3,14 @@ import { withApiHandler, ApiContext } from '@/lib/api-handler';
 import { AppError, ErrorCode } from '@/lib/errors';
 import { STATUS_CODES } from '@/lib/config/http';
 import { createLogger } from '@/lib/logger';
-import { isAdminAuthenticated } from '@/lib/auth';
+import { requireAdminAuth } from '@/lib/auth';
 
 const logger = createLogger('MetricsAPI');
 
 async function handleGet(context: ApiContext) {
-  if (process.env.ADMIN_API_KEY) {
-    const authenticated = await isAdminAuthenticated(context.request);
-    if (!authenticated) {
-      throw new AppError(
-        'Unauthorized. Admin authentication required for metrics endpoint.',
-        ErrorCode.AUTHENTICATION_ERROR,
-        STATUS_CODES.UNAUTHORIZED
-      );
-    }
-  }
+  // SECURITY: Always require admin authentication.
+  // This ensures a "fail-closed" behavior if ADMIN_API_KEY is not configured.
+  await requireAdminAuth(context.request);
 
   const metrics = await register.metrics();
 

--- a/tests/security/metrics-auth.test.ts
+++ b/tests/security/metrics-auth.test.ts
@@ -1,0 +1,62 @@
+import { NextRequest } from 'next/server';
+import { GET } from '@/app/api/metrics/route';
+
+// Mock the dependencies
+jest.mock('@/lib/metrics', () => ({
+  register: {
+    metrics: jest.fn().mockResolvedValue('test_metric 1.0'),
+    contentType: 'text/plain',
+  },
+  httpRequestDuration: { observe: jest.fn() },
+  httpRequestErrors: { inc: jest.fn() },
+  httpRequestTotal: { inc: jest.fn() },
+}));
+
+describe('Metrics API Security', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it('FIX VERIFICATION: should NOT return metrics when ADMIN_API_KEY is NOT set', async () => {
+    // In production, if ADMIN_API_KEY is missing, it should FAIL CLOSED.
+    process.env.NODE_ENV = 'production';
+    delete process.env.ADMIN_API_KEY;
+
+    const request = new NextRequest('http://localhost:3000/api/metrics', {
+      method: 'GET',
+    });
+
+    const response = await GET(request);
+
+    // Should be 401 Unauthorized
+    expect(response.status).toBe(401);
+    const data = await response.json();
+    expect(data.error).toContain('Unauthorized');
+  });
+
+  it('should require authentication when ADMIN_API_KEY IS set', async () => {
+    process.env.NODE_ENV = 'production';
+    process.env.ADMIN_API_KEY = 'super-secret-key';
+
+    const request = new NextRequest('http://localhost:3000/api/metrics', {
+      method: 'GET',
+      headers: {
+        // No authorization header
+      },
+    });
+
+    const response = await GET(request);
+
+    // Should be 401 Unauthorized
+    expect(response.status).toBe(401);
+    const data = await response.json();
+    expect(data.error).toContain('Unauthorized');
+  });
+});


### PR DESCRIPTION
The `/api/metrics` endpoint was using a fail-open authentication pattern, where it only checked for admin authentication if the `ADMIN_API_KEY` environment variable was present. If the variable was missing (e.g., due to misconfiguration), the endpoint became publicly accessible in production.

I refactored the handler to use `requireAdminAuth` unconditionally, ensuring the endpoint "fails closed" even if the API key is not configured.

I also added a regression test `tests/security/metrics-auth.test.ts` to verify this behavior and documented the pattern in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [6747267804239174279](https://jules.google.com/task/6747267804239174279) started by @cpa03*