### PR TITLE
🛡️ Sentinel: [MEDIUM] Enhance SSRF detection with non-standard IP encodings

### DIFF
--- a/src/lib/security/suspicious-patterns.ts
+++ b/src/lib/security/suspicious-patterns.ts
@@ -344,6 +344,17 @@ const SUSPICIOUS_PATTERNS: Record<
       severity: 2,
       description: 'Internal service access attempt',
     },
+    {
+      pattern:
+        /(?:https?|gopher|ftp|dict|file):\/\/(?:0x[0-9a-f]+|[0-9]{8,12}|0[0-7]{10,12})\b/i,
+      severity: 3,
+      description: 'Non-standard IP encoding SSRF (hex, decimal, or octal)',
+    },
+    {
+      pattern: /\[?::ffff:(?:127\.0\.0\.1|169\.254\.\d+\.\d+)\]?/i,
+      severity: 3,
+      description: 'IPv6-mapped IPv4 SSRF',
+    },
     // Medium severity
     {
       pattern: /file:\/\//i,

--- a/tests/security/ssrf-bypass.test.ts
+++ b/tests/security/ssrf-bypass.test.ts
@@ -1,0 +1,42 @@
+
+import { NextRequest } from 'next/server';
+import { detectSuspiciousPatterns } from '@/lib/security/suspicious-patterns';
+
+describe('Suspicious Pattern Detection Bypasses', () => {
+  const createMockRequest = (
+    url: string,
+    headers: Record<string, string> = {}
+  ) => {
+    return new NextRequest(new URL(url, 'https://example.com'), {
+      headers: new Headers(headers),
+    });
+  };
+
+  it('should detect SSRF with hex-encoded IP', () => {
+    const request = createMockRequest('https://example.com/api/test?url=http://0x7f000001');
+    const result = detectSuspiciousPatterns(request, { minSeverity: 1 });
+    expect(result.detected).toBe(true);
+    expect(result.patterns.some(p => p.category === 'ssrf')).toBe(true);
+  });
+
+  it('should detect SSRF with decimal-encoded IP', () => {
+    const request = createMockRequest('https://example.com/api/test?url=http://2130706433');
+    const result = detectSuspiciousPatterns(request, { minSeverity: 1 });
+    expect(result.detected).toBe(true);
+    expect(result.patterns.some(p => p.category === 'ssrf')).toBe(true);
+  });
+
+  it('should detect SSRF with octal-encoded IP', () => {
+    const request = createMockRequest('https://example.com/api/test?url=http://017700000001');
+    const result = detectSuspiciousPatterns(request, { minSeverity: 1 });
+    expect(result.detected).toBe(true);
+    expect(result.patterns.some(p => p.category === 'ssrf')).toBe(true);
+  });
+
+  it('should detect SSRF with IPv6-mapped IPv4', () => {
+    const request = createMockRequest('https://example.com/api/test?url=http://[::ffff:127.0.0.1]');
+    const result = detectSuspiciousPatterns(request, { minSeverity: 1 });
+    expect(result.detected).toBe(true);
+    expect(result.patterns.some(p => p.category === 'ssrf')).toBe(true);
+  });
+});


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Simple SSRF filters often only look for standard decimal IP strings, allowing bypasses via hex, decimal, or octal encodings, or IPv6-mapped IPv4 addresses.
🎯 Impact: Attackers could bypass SSRF protections to access internal services (like cloud metadata) or localhost.
🔧 Fix: Added regex patterns to `suspicious-patterns.ts` to detect non-standard IP encodings and IPv6-mapped IPv4 addresses.
✅ Verification: Added `tests/security/ssrf-bypass.test.ts` and verified that all security tests pass.

---
*PR created automatically by Jules for task [13314798183915616214](https://jules.google.com/task/13314798183915616214) started by @cpa03*