### PR TITLE
⚡ Bolt: optimize database pagination round-trips

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import './.next/types/routes.d.ts';
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2456,7 +2456,6 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
       "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3199,7 +3198,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3222,7 +3220,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3245,7 +3242,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3262,7 +3258,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3279,7 +3274,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3296,7 +3290,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3313,7 +3306,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3330,7 +3322,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3347,7 +3338,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3364,7 +3354,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3381,7 +3370,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3398,7 +3386,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3415,7 +3402,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3438,7 +3424,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3461,7 +3446,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3484,7 +3468,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3507,7 +3490,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3530,7 +3512,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3553,7 +3534,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3576,7 +3556,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3599,7 +3578,6 @@
       "cpu": [
         "wasm32"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
@@ -3619,7 +3597,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3639,7 +3616,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3659,7 +3635,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -2456,6 +2456,7 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
       "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3198,6 +3199,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3220,6 +3222,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3242,6 +3245,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3258,6 +3262,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3274,6 +3279,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3290,6 +3296,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3306,6 +3313,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3322,6 +3330,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3338,6 +3347,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3354,6 +3364,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3370,6 +3381,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3386,6 +3398,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3402,6 +3415,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3424,6 +3438,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3446,6 +3461,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3468,6 +3484,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3490,6 +3507,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3512,6 +3530,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3534,6 +3553,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3556,6 +3576,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3578,6 +3599,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
@@ -3597,6 +3619,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3616,6 +3639,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3635,6 +3659,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [

--- a/src/lib/db/clarification.ts
+++ b/src/lib/db/clarification.ts
@@ -132,21 +132,12 @@ export class ClarificationService {
     );
     const offset = (page - 1) * pageSize;
 
-    let countQuery = client
-      .from(DB_TABLES.AGENT_LOGS)
-      .select('*', { count: 'exact', head: true });
-
-    if (agent) {
-      countQuery = countQuery.eq('agent', agent);
-    }
-
-    const { count, error: countError } = await countQuery;
-
-    if (countError) throw countError;
-
+    // PERFORMANCE OPTIMIZATION: Combine count and data queries into a single request
+    // using Supabase's select('*', { count: 'exact' }). This reduces database
+    // round-trips from 2 to 1.
     let query = client
       .from(DB_TABLES.AGENT_LOGS)
-      .select('*')
+      .select('*', { count: 'exact' })
       .order('timestamp', { ascending: false })
       .range(offset, offset + pageSize - 1);
 
@@ -154,7 +145,7 @@ export class ClarificationService {
       query = query.eq('agent', agent);
     }
 
-    const { data, error } = await query;
+    const { data, count, error } = await query;
 
     if (error) throw error;
 

--- a/src/lib/db/ideas.ts
+++ b/src/lib/db/ideas.ts
@@ -110,15 +110,12 @@ export class IdeaService {
     const offset = (page - 1) * pageSize;
 
     // Build the base query with common filters
-    let countQuery = client
+    // PERFORMANCE OPTIMIZATION: Combine count and data queries into a single request
+    // using Supabase's select('*', { count: 'exact' }). This reduces database
+    // round-trips from 2 to 1.
+    let query = client
       .from(DB_TABLES.IDEAS)
-      .select('*', { count: 'exact', head: true })
-      .eq('user_id', userId)
-      .is('deleted_at', null);
-
-    let dataQuery = client
-      .from(DB_TABLES.IDEAS)
-      .select('*')
+      .select('*', { count: 'exact' })
       .eq('user_id', userId)
       .is('deleted_at', null)
       .order('created_at', { ascending: false })
@@ -126,27 +123,17 @@ export class IdeaService {
 
     // Apply status filter if provided and not 'all'
     if (filters?.status && filters.status !== 'all') {
-      countQuery = countQuery.eq('status', filters.status);
-      dataQuery = dataQuery.eq('status', filters.status);
+      query = query.eq('status', filters.status);
     }
 
     // Apply search filter if provided (searches in title and raw_text)
     if (filters?.search && filters.search.trim()) {
       const searchTerm = `%${filters.search.trim().toLowerCase()}%`;
       // Use OR filter for searching across multiple columns
-      countQuery = countQuery.or(
-        `title.ilike.${searchTerm},raw_text.ilike.${searchTerm}`
-      );
-      dataQuery = dataQuery.or(
-        `title.ilike.${searchTerm},raw_text.ilike.${searchTerm}`
-      );
+      query = query.or(`title.ilike.${searchTerm},raw_text.ilike.${searchTerm}`);
     }
 
-    const { count, error: countError } = await countQuery;
-
-    if (countError) throw countError;
-
-    const { data, error } = await dataQuery;
+    const { data, count, error } = await query;
 
     if (error) throw error;
 

--- a/src/lib/db/vectors.ts
+++ b/src/lib/db/vectors.ts
@@ -74,22 +74,12 @@ export class VectorService {
     );
     const offset = (page - 1) * pageSize;
 
-    let countQuery = client
-      .from(DB_TABLES.VECTORS)
-      .select('*', { count: 'exact', head: true })
-      .eq('idea_id', ideaId);
-
-    if (referenceType) {
-      countQuery = countQuery.eq('reference_type', referenceType);
-    }
-
-    const { count, error: countError } = await countQuery;
-
-    if (countError) throw countError;
-
+    // PERFORMANCE OPTIMIZATION: Combine count and data queries into a single request
+    // using Supabase's select('*', { count: 'exact' }). This reduces database
+    // round-trips from 2 to 1.
     let query = client
       .from(DB_TABLES.VECTORS)
-      .select('*')
+      .select('*', { count: 'exact' })
       .eq('idea_id', ideaId)
       .order('created_at', { ascending: false })
       .range(offset, offset + pageSize - 1);
@@ -98,7 +88,7 @@ export class VectorService {
       query = query.eq('reference_type', referenceType);
     }
 
-    const { data, error } = await query;
+    const { data, count, error } = await query;
 
     if (error) throw error;
 

--- a/tests/db/services.test.ts
+++ b/tests/db/services.test.ts
@@ -1,6 +1,8 @@
 import { TaskService } from '@/lib/db/tasks';
 import { DeliverableService } from '@/lib/db/deliverables';
 import { IdeaService } from '@/lib/db/ideas';
+import { VectorService } from '@/lib/db/vectors';
+import { ClarificationService } from '@/lib/db/clarification';
 import type { ClientProvider } from '@/lib/db/ideas';
 import { API_ERROR_MESSAGES } from '@/lib/config/error-messages';
 
@@ -20,7 +22,7 @@ interface MockSupabaseChain {
   update: jest.Mock;
   delete: jest.Mock;
   range: jest.Mock;
-  _result: { data: unknown; error: Error | null };
+  _result: { data: unknown; count: number | null; error: Error | null };
   then: (
     resolve: (value: unknown) => unknown,
     reject?: (reason: unknown) => unknown
@@ -32,14 +34,14 @@ const createMockSupabaseClient = (): MockSupabaseChain => {
     from: jest.fn(),
     insert: jest.fn(),
     select: jest.fn(),
-    single: jest.fn().mockResolvedValue({ data: null, error: null }),
+    single: jest.fn().mockResolvedValue({ data: null, count: null, error: null }),
     eq: jest.fn(),
     is: jest.fn(),
     order: jest.fn(),
     update: jest.fn(),
     delete: jest.fn(),
     range: jest.fn(),
-    _result: { data: null, error: null },
+    _result: { data: null, count: null, error: null },
     then: function (
       resolve: (value: unknown) => unknown,
       reject?: (reason: unknown) => unknown
@@ -733,10 +735,10 @@ describe('Database Services', () => {
     });
 
     describe('getUserIdeasPaginated', () => {
-      it('should return paginated ideas', async () => {
+      it('should return paginated ideas with total count', async () => {
         const ideas = [{ id: 'idea-1', user_id: 'user-1', title: 'Idea 1' }];
 
-        mockClient._result = { data: ideas, error: null };
+        mockClient._result = { data: ideas, count: 1, error: null };
 
         const result = await ideaService.getUserIdeasPaginated('user-1', {
           page: 1,
@@ -744,12 +746,29 @@ describe('Database Services', () => {
         });
 
         expect(result.data).toEqual(ideas);
+        expect(result.total).toBe(1);
         expect(result.page).toBe(1);
         expect(result.pageSize).toBe(10);
+        expect(result.hasMore).toBe(false);
+      });
+
+      it('should correctly identify when more pages are available', async () => {
+        const ideas = [{ id: 'idea-1', user_id: 'user-1', title: 'Idea 1' }];
+
+        mockClient._result = { data: ideas, count: 15, error: null };
+
+        const result = await ideaService.getUserIdeasPaginated('user-1', {
+          page: 1,
+          pageSize: 10,
+        });
+
+        expect(result.data).toEqual(ideas);
+        expect(result.total).toBe(15);
+        expect(result.hasMore).toBe(true);
       });
 
       it('should use default pagination options', async () => {
-        mockClient._result = { data: [], error: null };
+        mockClient._result = { data: [], count: 0, error: null };
 
         const result = await ideaService.getUserIdeasPaginated('user-1');
 
@@ -777,6 +796,68 @@ describe('Database Services', () => {
         const result = await ideaService.getIdeaSession('nonexistent');
 
         expect(result).toBeNull();
+      });
+    });
+  });
+
+  describe('VectorService', () => {
+    let vectorService: VectorService;
+    let mockProvider: ClientProvider;
+    let mockClient: ReturnType<typeof createMockSupabaseClient>;
+
+    beforeEach(() => {
+      mockProvider = createMockClientProvider();
+      mockClient = createMockSupabaseClient();
+      (mockProvider.getClient as jest.Mock).mockReturnValue(mockClient);
+      vectorService = new VectorService(mockProvider);
+    });
+
+    describe('getVectorsPaginated', () => {
+      it('should return paginated vectors with total count', async () => {
+        const vectors = [
+          { id: 'v-1', idea_id: 'idea-1', reference_type: 'context' },
+        ];
+        mockClient._result = { data: vectors, count: 1, error: null };
+
+        const result = await vectorService.getVectorsPaginated('idea-1', 'context', {
+          page: 1,
+          pageSize: 10,
+        });
+
+        expect(result.data).toEqual(vectors);
+        expect(result.total).toBe(1);
+        expect(result.hasMore).toBe(false);
+      });
+    });
+  });
+
+  describe('ClarificationService', () => {
+    let clarificationService: ClarificationService;
+    let mockProvider: ClientProvider;
+    let mockClient: ReturnType<typeof createMockSupabaseClient>;
+
+    beforeEach(() => {
+      mockProvider = createMockClientProvider();
+      mockClient = createMockSupabaseClient();
+      (mockProvider.getClient as jest.Mock).mockReturnValue(mockClient);
+      clarificationService = new ClarificationService(mockProvider);
+    });
+
+    describe('getAgentLogsPaginated', () => {
+      it('should return paginated agent logs with total count', async () => {
+        const logs = [
+          { id: 'log-1', agent: 'test-agent', action: 'test-action' },
+        ];
+        mockClient._result = { data: logs, count: 1, error: null };
+
+        const result = await clarificationService.getAgentLogsPaginated('test-agent', {
+          page: 1,
+          pageSize: 10,
+        });
+
+        expect(result.data).toEqual(logs);
+        expect(result.total).toBe(1);
+        expect(result.hasMore).toBe(false);
       });
     });
   });


### PR DESCRIPTION
💡 **What**: Consolidated database pagination queries by replacing separate count and data requests with a single consolidated call.

🎯 **Why**: Previously, paginated listing operations required two sequential database round-trips: one to get the total count (`head: true`) and another to fetch the actual page data. This added unnecessary latency, especially in Edge environments.

📊 **Impact**: Reduces database round-trips from 2 to 1 for Ideas, Vectors, and Agent Log pagination. This effectively halves the database-related latency for these operations, leading to faster UI responses for list views.

🔬 **Measurement**: Verified via `tests/db/services.test.ts`, which was updated to mock and validate the new single-query response structure. Full test suite (1600+ tests) passed successfully.

---
*PR created automatically by Jules for task [5335318928471857024](https://jules.google.com/task/5335318928471857024) started by @cpa03*