### PR TITLE
🛡️ Sentinel: Fix HTML Sanitization Fast-path Bypass

### DIFF
--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -214,7 +214,7 @@ const HTML_ESCAPE_REGEX = new RegExp(
  * or dangerous protocols (javascript:, data:text/html).
  */
 const NEEDS_SANITIZATION_REGEX =
-  /[<>&"'/`]|\bon\w+\s*=|j\s*a\s*v\s*a\s*s\s*c\s*r\s*i\s*p\s*t\s*:|d\s*a\s*t\s*a\s*:\s*t\s*e\s*x\s*t\s*\/\s*h\s*t\s*m\s*l/i;
+  /[<>&"'/`]|\bon\w+\s*=|(?:\b|[^a-z0-9])(?:j\s*a\s*v\s*a\s*s\s*c\s*r\s*i\s*p\s*t|v\s*b\s*s\s*c\s*r\s*i\s*p\s*t|l\s*i\s*v\s*e\s*s\s*c\s*r\s*i\s*p\s*t)\s*:|d\s*a\s*t\s*a\s*:\s*(?:t\s*e\s*x\s*t\s*\/\s*h\s*t\s*m\s*l|i\s*m\s*a\s*g\s*e\s*\/\s*s\s*v\s*g\s*\+\s*x\s*m\s*l)/i;
 
 /**
  * Sanitizes HTML content by removing script tags and escaping HTML entities

--- a/tests/security/sanitize-comprehensive.test.ts
+++ b/tests/security/sanitize-comprehensive.test.ts
@@ -1,0 +1,57 @@
+import { sanitizeHtml } from '@/lib/validation';
+
+describe('sanitizeHtml Comprehensive Security', () => {
+  it('should redact javascript: protocol even if it does not contain other special chars', () => {
+    const input = 'javascript:alert(1)';
+    const sanitized = sanitizeHtml(input);
+    expect(sanitized).toContain('[REDACTED_PROTOCOL]');
+    expect(sanitized).not.toContain('javascript:');
+  });
+
+  it('should redact vbscript: protocol even if it does not contain other special chars', () => {
+    const input = 'vbscript:alert(1)';
+    const sanitized = sanitizeHtml(input);
+    expect(sanitized).toContain('[REDACTED_PROTOCOL]');
+    expect(sanitized).not.toContain('vbscript:');
+  });
+
+  it('should redact livescript: protocol even if it does not contain other special chars', () => {
+    const input = 'livescript:alert(1)';
+    const sanitized = sanitizeHtml(input);
+    expect(sanitized).toContain('[REDACTED_PROTOCOL]');
+    expect(sanitized).not.toContain('livescript:');
+  });
+
+  it('should redact dangerous data: URIs (text/html) even if they do not contain other special chars', () => {
+    const input = 'data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==';
+    const sanitized = sanitizeHtml(input);
+    expect(sanitized).toContain('[REDACTED_DATA_URI]');
+    expect(sanitized).not.toContain('data:text/html');
+  });
+
+  it('should redact dangerous data: URIs (image/svg+xml) even if they do not contain other special chars', () => {
+    const input = 'data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=';
+    const sanitized = sanitizeHtml(input);
+    expect(sanitized).toContain('[REDACTED_DATA_URI]');
+    expect(sanitized).not.toContain('data:image/svg+xml');
+  });
+
+  it('should catch event handlers with different obfuscations', () => {
+    const cases = [
+      '<img src=x onerror=alert(1)>',
+      '<img/src="x"/onerror=alert(1)>',
+      '<svg onload=alert(1)>',
+      '<details open ontoggle=alert(1)>'
+    ];
+
+    for (const input of cases) {
+      const sanitized = sanitizeHtml(input);
+      expect(sanitized.toLowerCase()).not.toContain('onerror');
+      expect(sanitized.toLowerCase()).not.toContain('onload');
+      expect(sanitized.toLowerCase()).not.toContain('ontoggle');
+      // Should also be escaped
+      expect(sanitized).not.toContain('<');
+      expect(sanitized).not.toContain('>');
+    }
+  });
+});


### PR DESCRIPTION
🛡️ Sentinel has identified and resolved a potential XSS bypass in the HTML sanitization logic.

### 🚨 Severity: HIGH

### 💡 Vulnerability
The performance-optimized "fast-path" for HTML sanitization (\`NEEDS_SANITIZATION_REGEX\`) was out of sync with the actual sanitization rules. Specifically, it did not trigger for:
- \`vbscript:\` and \`livescript:\` protocols.
- \`data:image/svg+xml\` URIs (which can contain executable scripts).

### 🎯 Impact
Malicious inputs using these protocols could bypass sanitization and be stored/rendered as-is, potentially leading to Stored Cross-Site Scripting (XSS) if rendered in a context where these protocols are executable or if further truncation breaks subsequent safety checks.

### 🔧 Fix
1.  **Hardened Fast-path**: Updated \`NEEDS_SANITIZATION_REGEX\` to include all dangerous protocols defined in \`SANITIZATION_CONFIG\`.
2.  **Improved Robustness**: Added word boundary checks (\`\\b\`) to the protocol regex to reduce false positives while ensuring reliable detection of malicious prefixes.
3.  **Comprehensive Testing**: Added a new test suite that specifically targets these bypass vectors.

### ✅ Verification
- Run \`pnpm test tests/security/sanitize-comprehensive.test.ts\` to verify the specific fixes.
- Run \`pnpm test tests/security/\` to ensure no regressions in other security components.
- Verified with \`pnpm lint\`.

---
*PR created automatically by Jules for task [937659009778794445](https://jules.google.com/task/937659009778794445) started by @cpa03*