### PR TITLE
⚡ Bolt: resolve N+1 query in similarity search

### DIFF
--- a/src/lib/similarity-service.ts
+++ b/src/lib/similarity-service.ts
@@ -6,7 +6,6 @@
  */
 
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
-import { dbService } from './db';
 import { createLogger } from './logger';
 import { SIMILARITY_CONFIG } from './config/similarity-config';
 import {
@@ -119,36 +118,46 @@ export async function findSimilarIdeas(
     .filter((r: { idea_id: string }) => r.idea_id !== ideaId)
     .slice(0, limit);
 
-  // Get full idea details for each similar idea
-  const similarIdeas: SimilarIdea[] = await Promise.all(
-    filteredResults.map(
-      async (result: { idea_id: string; similarity: number }) => {
-        try {
-          const idea = await dbService.getIdea(result.idea_id);
+  // PERFORMANCE OPTIMIZATION (Issue #1928 - N+1 Query Resolution):
+  // ===========================================================================
+  // Resolve N+1 query pattern by fetching all idea details in a single bulk query
+  // using .in() filter. This reduces database round-trips from 1+N to exactly 2.
+  //
+  // OLD (N+1): 1 query for similarity + N queries for idea details (O(N) queries)
+  // NEW (Optimized): 1 query for similarity + 1 bulk query for details (O(1) queries)
+  const ideaIds = filteredResults.map((r: { idea_id: string }) => r.idea_id);
 
-          // Only include ideas belonging to the user and not deleted
-          if (idea && idea.user_id === userId && !idea.deleted_at) {
-            return {
-              id: idea.id,
-              title: idea.title,
-              status: idea.status,
-              similarity: result.similarity,
-              createdAt: idea.created_at,
-            };
-          }
-        } catch (error) {
-          logger.warn('Failed to get idea details', {
-            ideaId: result.idea_id,
-            error,
-          });
-        }
-        return null;
-      }
-    )
-  );
+  if (ideaIds.length === 0) return [];
 
-  // Filter out nulls
-  return similarIdeas.filter(Boolean) as SimilarIdea[];
+  const { data: ideasData, error: ideasError } = await supabase
+    .from(DB_TABLES.IDEAS)
+    .select('*')
+    .in(DB_COLUMNS.ID, ideaIds)
+    .eq(DB_COLUMNS.USER_ID, userId)
+    .is(DB_COLUMNS.DELETED_AT, null);
+
+  if (ideasError) {
+    logger.error('Failed to fetch similar ideas details:', ideasError);
+    return [];
+  }
+
+  // PERFORMANCE: Map results back to maintain original similarity sorting from RPC
+  const ideasMap = new Map((ideasData || []).map((idea) => [idea.id, idea]));
+
+  return filteredResults
+    .map((result: { idea_id: string; similarity: number }) => {
+      const idea = ideasMap.get(result.idea_id);
+      if (!idea) return null;
+
+      return {
+        id: idea.id,
+        title: idea.title,
+        status: idea.status,
+        similarity: result.similarity,
+        createdAt: idea.created_at,
+      };
+    })
+    .filter(Boolean) as SimilarIdea[];
 }
 
 /**

--- a/tests/similarity-service.test.ts
+++ b/tests/similarity-service.test.ts
@@ -1,0 +1,136 @@
+import { findSimilarIdeas } from '@/lib/similarity-service';
+
+// Mock Supabase client
+const mockSingle = jest.fn();
+const mockEq = jest.fn().mockReturnValue({ eq: jest.fn().mockReturnValue({ single: mockSingle }) });
+const mockRpc = jest.fn();
+const mockIn = jest.fn().mockReturnThis();
+
+const mockFrom = jest.fn((table) => {
+  if (table === 'vectors') {
+    return {
+      select: () => ({
+        eq: () => ({
+          eq: () => ({
+            single: mockSingle,
+          }),
+        }),
+      }),
+    };
+  }
+  if (table === 'ideas') {
+    return {
+      select: () => ({
+        in: mockIn,
+      }),
+    };
+  }
+  return {};
+});
+
+jest.mock('@supabase/supabase-js', () => ({
+  createClient: jest.fn(() => ({
+    from: mockFrom,
+    rpc: mockRpc,
+  })),
+}));
+
+// Mock logger
+jest.mock('@/lib/logger', () => ({
+  createLogger: jest.fn(() => ({
+    debug: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+  })),
+}));
+
+describe('SimilarityService', () => {
+  const userId = 'user-123';
+  const ideaId = 'idea-123';
+  let originalWindow: unknown;
+
+  beforeAll(() => {
+    originalWindow = global.window;
+  });
+
+  afterAll(() => {
+    // @ts-expect-error - restoring window
+    global.window = originalWindow;
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://example.supabase.co';
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-key';
+
+    // Simulate server environment
+    // @ts-expect-error - deleting window
+    delete global.window;
+  });
+
+  describe('findSimilarIdeas', () => {
+    it('should fetch similar ideas in a single bulk query and maintain sorting', async () => {
+      // 1. Mock vector retrieval
+      mockSingle.mockResolvedValueOnce({
+        data: { embedding: [0.1, 0.2] },
+        error: null,
+      });
+
+      // 2. Mock RPC result (similarity search)
+      const rpcResults = [
+        { idea_id: 'similar-1', similarity: 0.9 },
+        { idea_id: 'similar-2', similarity: 0.8 },
+      ];
+      mockRpc.mockResolvedValueOnce({
+        data: rpcResults,
+        error: null,
+      });
+
+      // 3. Mock bulk ideas retrieval
+      const mockIdeas = [
+        { id: 'similar-2', title: 'Idea 2', status: 'draft', created_at: '2026-01-02', user_id: userId },
+        { id: 'similar-1', title: 'Idea 1', status: 'completed', created_at: '2026-01-01', user_id: userId },
+      ];
+
+      mockIn.mockReturnValueOnce({
+        eq: jest.fn().mockReturnValueOnce({
+          is: jest.fn().mockResolvedValueOnce({
+            data: mockIdeas,
+            error: null,
+          })
+        })
+      });
+
+      const result = await findSimilarIdeas(ideaId, userId);
+
+      // Verify results
+      expect(result).toHaveLength(2);
+
+      // Verify sorting is maintained from RPC (similar-1 first with 0.9)
+      expect(result[0].id).toBe('similar-1');
+      expect(result[0].similarity).toBe(0.9);
+      expect(result[0].title).toBe('Idea 1');
+
+      expect(result[1].id).toBe('similar-2');
+      expect(result[1].similarity).toBe(0.8);
+      expect(result[1].title).toBe('Idea 2');
+
+      // Verify bulk query was used
+      expect(mockIn).toHaveBeenCalledWith('id', ['similar-1', 'similar-2']);
+    });
+
+    it('should return empty array if no embeddings found', async () => {
+      mockSingle.mockResolvedValueOnce({ data: null, error: null });
+
+      const result = await findSimilarIdeas(ideaId, userId);
+      expect(result).toEqual([]);
+    });
+
+    it('should handle RPC errors', async () => {
+      mockSingle.mockResolvedValueOnce({ data: { embedding: [0.1] }, error: null });
+      mockRpc.mockResolvedValueOnce({ data: null, error: { message: 'RPC Error' } });
+
+      await expect(findSimilarIdeas(ideaId, userId)).rejects.toThrow();
+    });
+  });
+});


### PR DESCRIPTION
💡 What: Optimized the `findSimilarIdeas` function in `src/lib/similarity-service.ts`.
🎯 Why: It previously had an N+1 query pattern where it fetched full idea details one-by-one for each similarity result.
📊 Impact: Reduces database round-trips from 1+N (e.g., 6 for limit=5) to exactly 2.
🔬 Measurement: Verified using a new test suite `tests/similarity-service.test.ts` which confirms bulk query usage and correct sorting.

---
*PR created automatically by Jules for task [2355380361530250559](https://jules.google.com/task/2355380361530250559) started by @cpa03*