### PR TITLE
🛡️ Sentinel: [HIGH] Fix Supabase filter injection

### DIFF
--- a/src/lib/db/ideas.ts
+++ b/src/lib/db/ideas.ts
@@ -128,9 +128,16 @@ export class IdeaService {
 
     // Apply search filter if provided (searches in title and raw_text)
     if (filters?.search && filters.search.trim()) {
-      const searchTerm = `%${filters.search.trim().toLowerCase()}%`;
+      // SECURITY: Sanitize and quote the search term to prevent Supabase filter injection.
+      // Since PostgREST uses commas as separators in .or() filters, unquoted search
+      // terms containing commas can cause syntax errors or unintended query logic.
+      // Wrapping the search term in double quotes and escaping existing double quotes
+      // ensures the term is treated as a single value.
+      const safeSearchTerm = `"%${filters.search.trim().toLowerCase().replace(/"/g, '""')}%"`;
       // Use OR filter for searching across multiple columns
-      query = query.or(`title.ilike.${searchTerm},raw_text.ilike.${searchTerm}`);
+      query = query.or(
+        `title.ilike.${safeSearchTerm},raw_text.ilike.${safeSearchTerm}`
+      );
     }
 
     const { data, count, error } = await query;

--- a/tests/db/ideas-security.test.ts
+++ b/tests/db/ideas-security.test.ts
@@ -1,0 +1,90 @@
+import { IdeaService } from '@/lib/db/ideas';
+import type { ClientProvider } from '@/lib/db/ideas';
+
+const createMockClientProvider = (): ClientProvider => ({
+  getClient: jest.fn(),
+  getAdmin: jest.fn(),
+});
+
+interface MockSupabaseChain {
+  from: jest.Mock;
+  select: jest.Mock;
+  eq: jest.Mock;
+  is: jest.Mock;
+  order: jest.Mock;
+  range: jest.Mock;
+  or: jest.Mock;
+  then: (
+    resolve: (value: unknown) => unknown,
+    reject?: (reason: unknown) => unknown
+  ) => Promise<unknown>;
+}
+
+const createMockSupabaseClient = (): MockSupabaseChain => {
+  const chain: MockSupabaseChain = {
+    from: jest.fn(),
+    select: jest.fn(),
+    eq: jest.fn(),
+    is: jest.fn(),
+    order: jest.fn(),
+    range: jest.fn(),
+    or: jest.fn(),
+    then: function (
+      resolve: (value: unknown) => unknown,
+      reject?: (reason: unknown) => unknown
+    ) {
+      return Promise.resolve({ data: [], count: 0, error: null }).then(resolve, reject);
+    },
+  };
+
+  chain.from.mockReturnValue(chain);
+  chain.select.mockReturnValue(chain);
+  chain.eq.mockReturnValue(chain);
+  chain.is.mockReturnValue(chain);
+  chain.order.mockReturnValue(chain);
+  chain.range.mockReturnValue(chain);
+  chain.or.mockReturnValue(chain);
+
+  return chain;
+};
+
+describe('IdeaService Security', () => {
+  let ideaService: IdeaService;
+  let mockProvider: ClientProvider;
+  let mockClient: MockSupabaseChain;
+
+  beforeEach(() => {
+    mockProvider = createMockClientProvider();
+    mockClient = createMockSupabaseClient();
+    (mockProvider.getClient as jest.Mock).mockReturnValue(mockClient);
+    ideaService = new IdeaService(mockProvider);
+  });
+
+  describe('getUserIdeasPaginated search term escaping', () => {
+    it('should correctly handle search terms with commas', async () => {
+      const searchTerm = 'foo,bar';
+      await ideaService.getUserIdeasPaginated('user-1', {}, { search: searchTerm });
+
+      // Current (vulnerable) implementation will produce:
+      // title.ilike.%foo,bar%,raw_text.ilike.%foo,bar%
+      // Which PostgREST interprets incorrectly because of the unquoted comma.
+
+      const orCall = mockClient.or.mock.calls[0][0];
+
+      // We expect it to be properly quoted to be safe in PostgREST
+      expect(orCall).toContain('title.ilike."%foo,bar%"');
+      expect(orCall).toContain('raw_text.ilike."%foo,bar%"');
+    });
+
+    it('should correctly handle search terms with double quotes', async () => {
+      const searchTerm = 'foo"bar';
+      await ideaService.getUserIdeasPaginated('user-1', {}, { search: searchTerm });
+
+      const orCall = mockClient.or.mock.calls[0][0];
+
+      // Double quotes should be escaped by doubling them
+      expect(orCall).toContain('title.ilike."%foo""bar%"');
+      expect(orCall).toContain('raw_text.ilike."%foo""bar%"');
+    });
+  });
+});


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Supabase .or() filter injection via unquoted search terms containing commas.
🎯 Impact: Search terms with commas caused PostgREST to incorrectly split the filter, leading to 400 errors or potentially allowing logic manipulation.
🔧 Fix: Wrapped the search term in double quotes and escaped existing double quotes in the .or() filter string.
✅ Verification: Created `tests/db/ideas-security.test.ts` which mocks the Supabase client and verifies the generated filter string.

---
*PR created automatically by Jules for task [16616913367529283454](https://jules.google.com/task/16616913367529283454) started by @cpa03*