### PR TITLE
🎨 Palette: [Consistent Success Celebration] Consolidate confetti delight into reusable hook

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,5 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/components/CopyButton.tsx
+++ b/src/components/CopyButton.tsx
@@ -8,13 +8,12 @@ import {
   SVG_STROKE_WIDTHS,
   SVG_SIZES,
   SVG_VIEWBOX,
-  CONFETTI_COLORS,
-  COMPONENT_CONFIG,
 } from '@/lib/config';
 import { ToastOptions } from '@/components/ToastContainer';
 import { triggerHapticFeedback } from '@/lib/utils';
 import Tooltip from './Tooltip';
 import StatusAnnouncer from './StatusAnnouncer';
+import { useConfetti } from '@/hooks/useConfetti';
 
 export interface CopyButtonProps {
   textToCopy: string;
@@ -31,15 +30,6 @@ export interface CopyButtonProps {
 
 const logger = createLogger('CopyButton');
 
-interface ConfettiParticle {
-  id: string;
-  x: number;
-  y: number;
-  color: string;
-  delay: number;
-  size: number; // Size variation for more natural confetti effect
-}
-
 const CopyButtonComponent = function CopyButton({
   textToCopy,
   label = COPY_BUTTON_LABELS.DEFAULT_LABEL,
@@ -52,50 +42,15 @@ const CopyButtonComponent = function CopyButton({
   onCopy,
 }: CopyButtonProps) {
   const [copied, setCopied] = useState(false);
-  const [confetti, setConfetti] = useState<ConfettiParticle[]>([]);
+  const { particles, fire } = useConfetti();
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
-  const confettiTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   useEffect(() => {
     return () => {
       if (timeoutRef.current) {
         clearTimeout(timeoutRef.current);
       }
-      if (confettiTimeoutRef.current) {
-        clearTimeout(confettiTimeoutRef.current);
-      }
     };
-  }, []);
-
-  const generateConfetti = useCallback(() => {
-    if (confettiTimeoutRef.current) {
-      clearTimeout(confettiTimeoutRef.current);
-    }
-
-    const particles: ConfettiParticle[] = [];
-    const particleCount = CONFETTI_COLORS.PARTICLE_COUNT;
-    for (let i = 0; i < particleCount; i++) {
-      const angle = (i / particleCount) * Math.PI * 2;
-      const distance =
-        CONFETTI_COLORS.MIN_DISTANCE +
-        Math.random() * CONFETTI_COLORS.MAX_DISTANCE_VARIANCE;
-      const size =
-        CONFETTI_COLORS.MIN_SIZE +
-        Math.random() * CONFETTI_COLORS.MAX_SIZE_VARIANCE;
-      particles.push({
-        id: `confetti-${Date.now()}-${i}`,
-        x: Math.cos(angle) * distance,
-        y: Math.sin(angle) * distance,
-        color: CONFETTI_COLORS.PRIMARY[i % CONFETTI_COLORS.PRIMARY.length],
-        delay: i * CONFETTI_COLORS.PARTICLE_DELAY_MS,
-        size,
-      });
-    }
-    setConfetti(particles);
-    confettiTimeoutRef.current = setTimeout(
-      () => setConfetti([]),
-      COMPONENT_CONFIG.CONFETTI.CLEANUP_MS
-    );
   }, []);
 
   const handleCopy = useCallback(async () => {
@@ -107,7 +62,7 @@ const CopyButtonComponent = function CopyButton({
       await navigator.clipboard.writeText(textToCopy);
       triggerHapticFeedback();
       setCopied(true);
-      generateConfetti();
+      fire();
 
       timeoutRef.current = setTimeout(() => {
         setCopied(false);
@@ -140,7 +95,7 @@ const CopyButtonComponent = function CopyButton({
         });
       }
     }
-  }, [textToCopy, showToast, toastMessage, onCopy, generateConfetti]);
+  }, [textToCopy, showToast, toastMessage, onCopy, fire]);
 
   const baseClasses = `
     inline-flex items-center justify-center gap-2
@@ -238,7 +193,7 @@ const CopyButtonComponent = function CopyButton({
               </span>
             )}
           </button>
-          {confetti.map((particle) => (
+          {particles.map((particle) => (
             <span
               key={particle.id}
               className="absolute rounded-full pointer-events-none animate-copy-confetti"

--- a/src/components/EmailButton.tsx
+++ b/src/components/EmailButton.tsx
@@ -6,6 +6,7 @@ import Tooltip from './Tooltip';
 import StatusAnnouncer from './StatusAnnouncer';
 import { createLogger } from '@/lib/logger';
 import { triggerHapticFeedback } from '@/lib/utils';
+import { useConfetti } from '@/hooks/useConfetti';
 import {
   APP_CONFIG,
   UI_CONFIG,
@@ -56,6 +57,7 @@ const EmailButtonComponent = function EmailButton({
   onEmailSent,
 }: EmailButtonProps) {
   const [state, setState] = useState<'idle' | 'loading' | 'success'>('idle');
+  const { particles, fire } = useConfetti();
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
   const prefersReducedMotion = usePrefersReducedMotion();
 
@@ -93,6 +95,7 @@ const EmailButtonComponent = function EmailButton({
       });
 
       setState('success');
+      fire();
 
       timeoutRef.current = setTimeout(() => {
         setState('idle');
@@ -106,7 +109,7 @@ const EmailButtonComponent = function EmailButton({
       logger.error('Failed to open email client', error);
       setState('idle');
     }
-  }, [ideaTitle, ideaContent, sessionAnswers, onEmailSent, state]);
+  }, [ideaTitle, ideaContent, sessionAnswers, onEmailSent, state, fire]);
 
   const iconTransition = prefersReducedMotion
     ? ''
@@ -120,63 +123,84 @@ const EmailButtonComponent = function EmailButton({
         disabled={false}
         position="top"
       >
-        <Button
-          variant="primary"
-          loading={state === 'loading'}
-          onClick={handleEmailClick}
-          aria-label={ariaLabel}
-          className={className}
-        >
-          <span
-            className={`relative flex items-center justify-center ${SVG_SIZES.MD}`}
+        <span className="relative inline-flex">
+          <Button
+            variant="primary"
+            loading={state === 'loading'}
+            onClick={handleEmailClick}
+            aria-label={ariaLabel}
+            className={className}
           >
-            <svg
-              className={`absolute inset-0 ${SVG_SIZES.MD} ${iconTransition} ${
-                state === 'success'
-                  ? 'opacity-0 scale-75'
-                  : 'opacity-100 scale-100'
-              }`}
-              fill="none"
-              viewBox={SVG_VIEWBOX.STANDARD}
-              stroke="currentColor"
-              strokeWidth={SVG_STROKE_WIDTHS.STANDARD}
-              aria-hidden="true"
+            <span
+              className={`relative flex items-center justify-center ${SVG_SIZES.MD}`}
             >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
-              />
-            </svg>
+              <svg
+                className={`absolute inset-0 ${SVG_SIZES.MD} ${iconTransition} ${
+                  state === 'success'
+                    ? 'opacity-0 scale-75'
+                    : 'opacity-100 scale-100'
+                }`}
+                fill="none"
+                viewBox={SVG_VIEWBOX.STANDARD}
+                stroke="currentColor"
+                strokeWidth={SVG_STROKE_WIDTHS.STANDARD}
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
+                />
+              </svg>
 
-            <svg
-              className={`absolute inset-0 ${SVG_SIZES.MD} text-green-700 ${iconTransition} ${
-                state === 'success'
-                  ? 'opacity-100 scale-100'
-                  : 'opacity-0 scale-50'
+              <svg
+                className={`absolute inset-0 ${SVG_SIZES.MD} text-green-700 ${iconTransition} ${
+                  state === 'success'
+                    ? 'opacity-100 scale-100'
+                    : 'opacity-0 scale-50'
+                }`}
+                fill="none"
+                viewBox={SVG_VIEWBOX.STANDARD}
+                stroke="currentColor"
+                strokeWidth={SVG_STROKE_WIDTHS.EXTRA_THICK}
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M5 13l4 4L19 7"
+                />
+              </svg>
+            </span>
+
+            <span
+              className={`${iconTransition} ${
+                state === 'success' ? 'text-green-100' : ''
               }`}
-              fill="none"
-              viewBox={SVG_VIEWBOX.STANDARD}
-              stroke="currentColor"
-              strokeWidth={SVG_STROKE_WIDTHS.EXTRA_THICK}
-              aria-hidden="true"
             >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M5 13l4 4L19 7"
-              />
-            </svg>
-          </span>
-
-          <span
-            className={`${iconTransition} ${
-              state === 'success' ? 'text-green-100' : ''
-            }`}
-          >
-            {state === 'success' ? successLabel : label}
-          </span>
-        </Button>
+              {state === 'success' ? successLabel : label}
+            </span>
+          </Button>
+          {particles.map((particle) => (
+            <span
+              key={particle.id}
+              className="absolute rounded-full pointer-events-none animate-copy-confetti"
+              style={
+                {
+                  left: '50%',
+                  top: '50%',
+                  width: `${particle.size}px`,
+                  height: `${particle.size}px`,
+                  backgroundColor: particle.color,
+                  '--confetti-x': `${particle.x}px`,
+                  '--confetti-y': `${particle.y}px`,
+                  animationDelay: `${particle.delay}ms`,
+                } as React.CSSProperties
+              }
+              aria-hidden="true"
+            />
+          ))}
+        </span>
       </Tooltip>
     </>
   );

--- a/src/components/ShareButton.tsx
+++ b/src/components/ShareButton.tsx
@@ -14,6 +14,7 @@ import { ToastOptions } from '@/components/ToastContainer';
 import { triggerHapticFeedback } from '@/lib/utils';
 import Tooltip from './Tooltip';
 import StatusAnnouncer from './StatusAnnouncer';
+import { useConfetti } from '@/hooks/useConfetti';
 
 export interface ShareButtonProps {
   shareUrl?: string;
@@ -54,6 +55,7 @@ const ShareButtonComponent = function ShareButton({
   onShare,
 }: ShareButtonProps) {
   const [shared, setShared] = useState(false);
+  const { particles, fire } = useConfetti();
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   // Cleanup timeout on unmount
@@ -112,6 +114,7 @@ const ShareButtonComponent = function ShareButton({
         triggerHapticFeedback();
         await navigator.share(shareData);
         setShared(true);
+        fire();
         logger.debug('Successfully shared via Web Share API', {
           shareTitle,
           shareUrl,
@@ -140,6 +143,7 @@ const ShareButtonComponent = function ShareButton({
         triggerHapticFeedback();
         await navigator.clipboard.writeText(shareUrl);
         setShared(true);
+        fire();
         logger.debug('Successfully copied share URL to clipboard', {
           shareUrl,
         });
@@ -167,6 +171,7 @@ const ShareButtonComponent = function ShareButton({
     showSuccessToast,
     showErrorToast,
     onShare,
+    fire,
   ]);
 
   const baseClasses = `
@@ -203,65 +208,86 @@ const ShareButtonComponent = function ShareButton({
         disabled={false}
         position="top"
       >
-        <button
-          onClick={handleShare}
-          className={`${baseClasses} ${variantClasses[variant]} ${glowClass} ${className}`}
-          aria-label={ariaLabel}
-          type="button"
-        >
-          <span
-            className={`relative flex items-center justify-center ${SVG_SIZES.MD}`}
+        <span className="relative inline-flex">
+          <button
+            onClick={handleShare}
+            className={`${baseClasses} ${variantClasses[variant]} ${glowClass} ${className}`}
+            aria-label={ariaLabel}
+            type="button"
           >
-            {/* Share icon */}
-            <svg
-              className={`
+            <span
+              className={`relative flex items-center justify-center ${SVG_SIZES.MD}`}
+            >
+              {/* Share icon */}
+              <svg
+                className={`
               absolute inset-0 ${SVG_SIZES.MD} transition-all duration-200
               ${shared ? 'opacity-0 scale-75' : 'opacity-100 scale-100'}
             `}
-              fill="none"
-              viewBox={SVG_VIEWBOX.STANDARD}
-              stroke="currentColor"
-              strokeWidth={SVG_STROKE_WIDTHS.STANDARD}
-              aria-hidden="true"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.368 2.684 3 3 0 00-5.368-2.684z"
-              />
-            </svg>
+                fill="none"
+                viewBox={SVG_VIEWBOX.STANDARD}
+                stroke="currentColor"
+                strokeWidth={SVG_STROKE_WIDTHS.STANDARD}
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.368 2.684 3 3 0 00-5.368-2.684z"
+                />
+              </svg>
 
-            {/* Checkmark icon when shared */}
-            <svg
-              className={`
+              {/* Checkmark icon when shared */}
+              <svg
+                className={`
               absolute inset-0 ${SVG_SIZES.MD} text-green-500 transition-all duration-200
               ${shared ? 'opacity-100 scale-100' : 'opacity-0 scale-50'}
             `}
-              fill="none"
-              viewBox={SVG_VIEWBOX.STANDARD}
-              stroke="currentColor"
-              strokeWidth={SVG_STROKE_WIDTHS.THICK}
-              aria-hidden="true"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M5 13l4 4L19 7"
-              />
-            </svg>
-          </span>
+                fill="none"
+                viewBox={SVG_VIEWBOX.STANDARD}
+                stroke="currentColor"
+                strokeWidth={SVG_STROKE_WIDTHS.THICK}
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M5 13l4 4L19 7"
+                />
+              </svg>
+            </span>
 
-          {variant !== 'icon-only' && (
-            <span
-              className={`
+            {variant !== 'icon-only' && (
+              <span
+                className={`
               transition-all duration-200
               ${shared ? 'text-green-400' : ''}
             `}
-            >
-              {shared ? successLabel : label}
-            </span>
-          )}
-        </button>
+              >
+                {shared ? successLabel : label}
+              </span>
+            )}
+          </button>
+          {particles.map((particle) => (
+            <span
+              key={particle.id}
+              className="absolute rounded-full pointer-events-none animate-copy-confetti"
+              style={
+                {
+                  left: '50%',
+                  top: '50%',
+                  width: `${particle.size}px`,
+                  height: `${particle.size}px`,
+                  backgroundColor: particle.color,
+                  '--confetti-x': `${particle.x}px`,
+                  '--confetti-y': `${particle.y}px`,
+                  animationDelay: `${particle.delay}ms`,
+                } as React.CSSProperties
+              }
+              aria-hidden="true"
+            />
+          ))}
+        </span>
       </Tooltip>
     </>
   );

--- a/src/hooks/useConfetti.ts
+++ b/src/hooks/useConfetti.ts
@@ -1,0 +1,78 @@
+'use client';
+
+import { useState, useCallback, useRef, useEffect } from 'react';
+import { CONFETTI_COLORS, COMPONENT_CONFIG } from '@/lib/config';
+import { usePrefersReducedMotion } from '@/hooks/usePrefersReducedMotion';
+
+export interface ConfettiParticle {
+  id: string;
+  x: number;
+  y: number;
+  color: string;
+  delay: number;
+  size: number;
+}
+
+/**
+ * useConfetti Hook
+ *
+ * Manages a local burst of confetti particles for UI delight.
+ * Follows the visual pattern established in CopyButton.
+ *
+ * Features:
+ * - Respects prefers-reduced-motion
+ * - Automatic cleanup of particles
+ * - Highly customizable via centralized config
+ */
+export function useConfetti() {
+  const [particles, setParticles] = useState<ConfettiParticle[]>([]);
+  const confettiTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const prefersReducedMotion = usePrefersReducedMotion();
+
+  useEffect(() => {
+    return () => {
+      if (confettiTimeoutRef.current) {
+        clearTimeout(confettiTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  const fire = useCallback(() => {
+    if (prefersReducedMotion) return;
+
+    if (confettiTimeoutRef.current) {
+      clearTimeout(confettiTimeoutRef.current);
+    }
+
+    const newParticles: ConfettiParticle[] = [];
+    const particleCount = CONFETTI_COLORS.PARTICLE_COUNT;
+
+    for (let i = 0; i < particleCount; i++) {
+      const angle = (i / particleCount) * Math.PI * 2;
+      const distance =
+        CONFETTI_COLORS.MIN_DISTANCE +
+        Math.random() * CONFETTI_COLORS.MAX_DISTANCE_VARIANCE;
+      const size =
+        CONFETTI_COLORS.MIN_SIZE +
+        Math.random() * CONFETTI_COLORS.MAX_SIZE_VARIANCE;
+
+      newParticles.push({
+        id: `confetti-${Date.now()}-${i}-${Math.random().toString(36).substring(2, 7)}`,
+        x: Math.cos(angle) * distance,
+        y: Math.sin(angle) * distance,
+        color: CONFETTI_COLORS.PRIMARY[i % CONFETTI_COLORS.PRIMARY.length],
+        delay: i * CONFETTI_COLORS.PARTICLE_DELAY_MS,
+        size,
+      });
+    }
+
+    setParticles(newParticles);
+
+    confettiTimeoutRef.current = setTimeout(
+      () => setParticles([]),
+      COMPONENT_CONFIG.CONFETTI.CLEANUP_MS
+    );
+  }, [prefersReducedMotion]);
+
+  return { particles, fire };
+}

--- a/tests/useConfetti.test.ts
+++ b/tests/useConfetti.test.ts
@@ -1,0 +1,65 @@
+import { renderHook, act } from '@testing-library/react';
+import { useConfetti } from '@/hooks/useConfetti';
+import { usePrefersReducedMotion } from '@/hooks/usePrefersReducedMotion';
+
+// Mock the prefers reduced motion hook
+jest.mock('@/hooks/usePrefersReducedMotion', () => ({
+  usePrefersReducedMotion: jest.fn(),
+}));
+
+describe('useConfetti', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (usePrefersReducedMotion as jest.Mock).mockReturnValue(false);
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('starts with an empty particles array', () => {
+    const { result } = renderHook(() => useConfetti());
+    expect(result.current.particles).toEqual([]);
+  });
+
+  it('generates particles when fire() is called', () => {
+    const { result } = renderHook(() => useConfetti());
+
+    act(() => {
+      result.current.fire();
+    });
+
+    expect(result.current.particles.length).toBeGreaterThan(0);
+    expect(result.current.particles[0]).toHaveProperty('id');
+    expect(result.current.particles[0]).toHaveProperty('x');
+    expect(result.current.particles[0]).toHaveProperty('y');
+  });
+
+  it('cleans up particles after duration', () => {
+    const { result } = renderHook(() => useConfetti());
+
+    act(() => {
+      result.current.fire();
+    });
+
+    expect(result.current.particles.length).toBeGreaterThan(0);
+
+    act(() => {
+      jest.advanceTimersByTime(5000); // Default cleanup is 3000ms
+    });
+
+    expect(result.current.particles).toEqual([]);
+  });
+
+  it('does not generate particles if prefers-reduced-motion is true', () => {
+    (usePrefersReducedMotion as jest.Mock).mockReturnValue(true);
+    const { result } = renderHook(() => useConfetti());
+
+    act(() => {
+      result.current.fire();
+    });
+
+    expect(result.current.particles).toEqual([]);
+  });
+});


### PR DESCRIPTION
### 💡 What: The UX enhancement added
This PR introduces a consistent "Success Celebration" pattern across the application's primary action buttons. I extracted the isolated confetti logic from `CopyButton` into a reusable `useConfetti` hook and integrated it into `ShareButton` and `EmailButton`.

### 🎯 Why: The user problem it solves
Previously, only copying text provided delightful visual feedback. By standardizing this across Share and Email actions, the interface feels more responsive, rewarding, and cohesive. It also improves code modularity by centralizing the particle generation and cleanup logic.

### ♿ Accessibility: Any a11y improvements made
- The `useConfetti` hook explicitly checks for the `prefers-reduced-motion` media query and skips particle generation if enabled.
- All particle rendering is marked with `aria-hidden="true"` to prevent screen reader noise.
- Maintained existing `StatusAnnouncer` integration for screen reader confirmation of actions.

### ✅ Verification Results
- **Unit Tests**: Added `tests/useConfetti.test.ts` verifying particle generation, cleanup, and reduced-motion handling. All passed.
- **Linting**: `pnpm lint` passed with no warnings.
- **Existing Tests**: All 88 test suites passed, including core button accessibility tests.

---
*PR created automatically by Jules for task [8335385052643825807](https://jules.google.com/task/8335385052643825807) started by @cpa03*