### PR TITLE
🛡️ Sentinel: [security improvement] Harden Task custom_fields sanitization

### DIFF
--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -4,7 +4,7 @@ import {
   ApiContext,
 } from '@/lib/api-handler';
 import { dbService, Task } from '@/lib/db';
-import { sanitizeHtml } from '@/lib/validation';
+import { sanitizeHtml, sanitizeObject } from '@/lib/validation';
 import { AppError, ErrorCode, ValidationError } from '@/lib/errors';
 import { requireAuth, verifyResourceOwnership } from '@/lib/auth';
 import { API_ERROR_MESSAGES } from '@/lib/config/error-messages';
@@ -159,8 +159,11 @@ async function handlePut(context: ApiContext) {
     if (body.complexity_score !== undefined)
       updates.complexity_score = body.complexity_score;
     if (body.risk_level !== undefined) updates.risk_level = body.risk_level;
-    if (body.custom_fields !== undefined)
-      updates.custom_fields = body.custom_fields;
+    if (body.custom_fields !== undefined) {
+      updates.custom_fields = body.custom_fields
+        ? sanitizeObject(body.custom_fields)
+        : body.custom_fields;
+    }
     if (body.milestone_id !== undefined)
       updates.milestone_id = body.milestone_id;
 

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -289,6 +289,34 @@ export function sanitizeHtml(input: string): string {
   return sanitized;
 }
 
+/**
+ * Recursively sanitizes all string values within an object or array.
+ * Useful for flexible JSON fields like custom_fields.
+ */
+export function sanitizeObject<T>(input: T): T {
+  if (input === null || input === undefined) {
+    return input;
+  }
+
+  if (typeof input === 'string') {
+    return sanitizeHtml(input) as unknown as T;
+  }
+
+  if (Array.isArray(input)) {
+    return input.map((item) => sanitizeObject(item)) as unknown as T;
+  }
+
+  if (typeof input === 'object' && input.constructor === Object) {
+    const sanitized: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(input)) {
+      sanitized[key] = sanitizeObject(value);
+    }
+    return sanitized as unknown as T;
+  }
+
+  return input;
+}
+
 export function buildErrorResponse(errors: ValidationError[]): Response {
   return new Response(
     JSON.stringify({

--- a/tests/security/task-custom-fields-sanitization.test.ts
+++ b/tests/security/task-custom-fields-sanitization.test.ts
@@ -1,0 +1,69 @@
+import { NextRequest } from 'next/server';
+import { PUT } from '@/app/api/tasks/[id]/route';
+import { dbService } from '@/lib/db';
+import { requireAuth, verifyResourceOwnership } from '@/lib/auth';
+
+jest.mock('@/lib/db');
+jest.mock('@/lib/auth');
+jest.mock('@/lib/logger', () => ({
+  createLogger: () => ({
+    info: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+    infoWithContext: jest.fn(),
+    errorWithContext: jest.fn(),
+    warnWithContext: jest.fn(),
+  }),
+  generateCorrelationId: () => 'test-id',
+  setCorrelationId: jest.fn(),
+}));
+
+describe('Task Custom Fields Sanitization', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (requireAuth as jest.Mock).mockResolvedValue({ id: 'u1' });
+    (verifyResourceOwnership as jest.Mock).mockReturnValue(undefined);
+  });
+
+  it('should recursively sanitize custom_fields on update', async () => {
+    (dbService.getTaskWithOwnership as jest.Mock).mockResolvedValue({
+      id: 't1',
+      idea: { user_id: 'u1' },
+    });
+    (dbService.updateTask as jest.Mock).mockImplementation(async (id, u) => ({
+      id,
+      ...u,
+    }));
+
+    const body = {
+      custom_fields: {
+        meta: '<script>alert("xss")</script>',
+        nested: {
+          key: '<img src=x onerror=alert(1)>',
+          list: ['<iframe src="javascript:alert(1)"></iframe>', 'safe'],
+        },
+        number: 123,
+        bool: true
+      },
+    };
+
+    const req = {
+      method: 'PUT',
+      url: 'http://localhost/api/tasks/t1',
+      nextUrl: { pathname: '/api/tasks/t1' },
+      headers: new Headers({ 'content-type': 'application/json' }),
+      json: async () => body,
+    } as unknown as NextRequest;
+
+    await PUT(req);
+
+    const call = (dbService.updateTask as jest.Mock).mock.calls[0][1];
+    expect(call.custom_fields.meta).not.toContain('<script');
+    expect(call.custom_fields.nested.key).not.toContain('onerror');
+    expect(call.custom_fields.nested.list[0]).not.toContain('<iframe');
+    expect(call.custom_fields.nested.list[1]).toBe('safe');
+    expect(call.custom_fields.number).toBe(123);
+    expect(call.custom_fields.bool).toBe(true);
+  });
+});


### PR DESCRIPTION
### 🛡️ Sentinel: Security Improvement - Harden Task custom_fields sanitization

🚨 **Severity**: MEDIUM (Defense in Depth)

💡 **Vulnerability**: 
Previously, the `custom_fields` property in Task update requests was passed directly to the database without sanitization. While most fields had explicit sanitization, this flexible JSON field could have been used to inject malicious scripts.

🎯 **Impact**: 
If `custom_fields` data is rendered in the UI without proper escaping (e.g., in a dynamic table or custom property viewer), it could lead to Stored Cross-Site Scripting (XSS) attacks.

🔧 **Fix**: 
- Introduced a new `sanitizeObject` utility in `src/lib/validation.ts` that recursively traverses objects and arrays, applying `sanitizeHtml` to every string found.
- Updated `src/app/api/tasks/[id]/route.ts` to apply this sanitization to the `custom_fields` property before updating the database.

✅ **Verification**: 
- Created `tests/security/task-custom-fields-sanitization.test.ts` which confirms that nested scripts and event handlers within `custom_fields` are correctly redacted while preserving non-string types (numbers, booleans).
- All security tests passed with 100% success rate.

---
*PR created automatically by Jules for task [238746180119343859](https://jules.google.com/task/238746180119343859) started by @cpa03*