### PR TITLE
🎨 Palette: select-all micro-interaction for ReferralLink code snippet

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,5 @@
+# Palette's Journal - Critical Learnings Only
+
+## 2026-07-16 - Selection Mechanics in Monospace Snippets
+**Learning:** Monospace code blocks (`<code>`) containing URLs (such as dynamic referral URLs) are difficult for trackpad and mobile users to cleanly select manually because standard double-clicking often excludes parameters, anchors, or trailing punctuation. While `CopyButton` is the primary mechanism, providing a secondary select-all-on-click mechanism on the code block itself bridges the gap for manual selection and drag/copy workflows, without compromising keyboard focus or screen-reader accessibility.
+**Action:** Always make inline/block code components keyboard-focusable (`tabIndex={0}`) and add click/keypress handlers to select all contents (`window.getSelection().selectNodeContents`) when displaying long hashes, URLs, or command snippets.

--- a/src/components/ReferralLink.tsx
+++ b/src/components/ReferralLink.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useMemo } from 'react';
+import React, { useMemo, useCallback } from 'react';
 import CopyButton from './CopyButton';
 import { createLogger } from '@/lib/logger';
 import { APP_CONFIG } from '@/lib/config/app';
@@ -9,6 +9,7 @@ import {
   SVG_VIEWBOX,
   REFERRAL_LINK_LABELS,
 } from '@/lib/config';
+import { triggerHapticFeedback } from '@/lib/utils';
 
 // Logger for growth tracking events
 const logger = createLogger('ReferralLink');
@@ -71,6 +72,35 @@ export default function ReferralLink({
     }
   };
 
+  // Micro-UX: Click or focus + Enter/Space to select all text for easy custom copy
+  const handleCodeClick = useCallback((e: React.MouseEvent<HTMLElement>) => {
+    triggerHapticFeedback();
+    const selection = window.getSelection();
+    if (selection) {
+      const range = document.createRange();
+      range.selectNodeContents(e.currentTarget);
+      selection.removeAllRanges();
+      selection.addRange(range);
+    }
+  }, []);
+
+  const handleCodeKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLElement>) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        triggerHapticFeedback();
+        const selection = window.getSelection();
+        if (selection) {
+          const range = document.createRange();
+          range.selectNodeContents(e.currentTarget);
+          selection.removeAllRanges();
+          selection.addRange(range);
+        }
+      }
+    },
+    []
+  );
+
   return (
     <div
       className={`bg-gradient-to-r from-primary-50 to-blue-50 rounded-lg p-4 border border-primary-100 ${className}`}
@@ -86,7 +116,13 @@ export default function ReferralLink({
             {REFERRAL_LINK_LABELS.DESCRIPTION}
           </p>
           <div className="flex items-center gap-2">
-            <code className="flex-1 min-w-0 px-3 py-2 bg-white border border-primary-200 rounded-md text-sm text-primary-800 truncate font-mono">
+            <code
+              onClick={handleCodeClick}
+              onKeyDown={handleCodeKeyDown}
+              tabIndex={0}
+              title="Click or press Enter/Space to select all"
+              className="flex-1 min-w-0 px-3 py-2 bg-white border border-primary-200 rounded-md text-sm text-primary-800 truncate font-mono cursor-pointer hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 transition-colors duration-200"
+            >
               {referralUrl}
             </code>
             <CopyButton

--- a/tests/ReferralLink.test.tsx
+++ b/tests/ReferralLink.test.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ReferralLink from '../src/components/ReferralLink';
+
+const mockSelectNodeContents = jest.fn();
+const mockRemoveAllRanges = jest.fn();
+const mockAddRange = jest.fn();
+
+const mockSelection = {
+  removeAllRanges: mockRemoveAllRanges,
+  addRange: mockAddRange,
+} as unknown as Selection;
+
+const mockRange = {
+  selectNodeContents: mockSelectNodeContents,
+} as unknown as Range;
+
+window.getSelection = jest.fn().mockReturnValue(mockSelection);
+document.createRange = jest.fn().mockReturnValue(mockRange);
+
+describe('ReferralLink', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the referral title, description, and link correctly', () => {
+    render(<ReferralLink referralCode="testcode123" />);
+
+    expect(screen.getByText(/Share Your Referral Link/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Invite friends and earn rewards when they sign up!/i)
+    ).toBeInTheDocument();
+    expect(screen.getByText(/signup\?ref=testcode123/i)).toBeInTheDocument();
+  });
+
+  it('selects the entire code container content on click', () => {
+    render(<ReferralLink referralCode="testcode123" />);
+
+    const codeElement = screen.getByText(/signup\?ref=testcode123/i);
+    fireEvent.click(codeElement);
+
+    expect(window.getSelection).toHaveBeenCalled();
+    expect(document.createRange).toHaveBeenCalled();
+    expect(mockSelectNodeContents).toHaveBeenCalledWith(codeElement);
+    expect(mockRemoveAllRanges).toHaveBeenCalled();
+    expect(mockAddRange).toHaveBeenCalledWith(mockRange);
+  });
+
+  it('selects the entire code container content on Enter press', () => {
+    render(<ReferralLink referralCode="testcode123" />);
+
+    const codeElement = screen.getByText(/signup\?ref=testcode123/i);
+    fireEvent.keyDown(codeElement, { key: 'Enter' });
+
+    expect(window.getSelection).toHaveBeenCalled();
+    expect(document.createRange).toHaveBeenCalled();
+    expect(mockSelectNodeContents).toHaveBeenCalledWith(codeElement);
+    expect(mockRemoveAllRanges).toHaveBeenCalled();
+    expect(mockAddRange).toHaveBeenCalledWith(mockRange);
+  });
+
+  it('selects the entire code container content on Space press', () => {
+    render(<ReferralLink referralCode="testcode123" />);
+
+    const codeElement = screen.getByText(/signup\?ref=testcode123/i);
+    fireEvent.keyDown(codeElement, { key: ' ' });
+
+    expect(window.getSelection).toHaveBeenCalled();
+    expect(document.createRange).toHaveBeenCalled();
+    expect(mockSelectNodeContents).toHaveBeenCalledWith(codeElement);
+    expect(mockRemoveAllRanges).toHaveBeenCalled();
+    expect(mockAddRange).toHaveBeenCalledWith(mockRange);
+  });
+
+  it('does not select content on tab or other keys', () => {
+    render(<ReferralLink referralCode="testcode123" />);
+
+    const codeElement = screen.getByText(/signup\?ref=testcode123/i);
+    fireEvent.keyDown(codeElement, { key: 'Tab' });
+
+    expect(window.getSelection).not.toHaveBeenCalled();
+    expect(document.createRange).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
This PR implements a click-to-select-all micro-UX enhancement on the `<code>` referral link container inside the dashboard's `ReferralLink` component. This enables frictionless selection for custom drag-to-copy interactions. It is keyboard accessible with full Enter/Space support, respects preferences for haptic feedback, has custom visual hover/focus visible rings, and includes dedicated unit test coverage.

---
*PR created automatically by Jules for task [6657586530158535164](https://jules.google.com/task/6657586530158535164) started by @cpa03*