### PR TITLE
⚡ Bolt: optimize pii redaction with lazy WeakSet allocation

### DIFF
--- a/src/lib/pii-redaction.ts
+++ b/src/lib/pii-redaction.ts
@@ -388,7 +388,7 @@ const MAX_RECURSION_DEPTH = PII_REDACTION_CONFIG.MAX_RECURSION_DEPTH;
 
 export function redactPIIInObject(
   obj: unknown,
-  seen = new WeakSet<object>(),
+  seen?: WeakSet<object>,
   depth = 0
 ): RedactionResult {
   if (depth > MAX_RECURSION_DEPTH) {
@@ -407,6 +407,11 @@ export function redactPIIInObject(
   // property iteration over numeric indices. These never contain PII strings.
   if (ArrayBuffer.isView(obj)) {
     return obj as unknown as RedactionResult;
+  }
+
+  // PERFORMANCE: Lazily allocate WeakSet only when actual object traversal is required
+  if (!seen) {
+    seen = new WeakSet<object>();
   }
 
   if (seen.has(obj)) {


### PR DESCRIPTION
### What:
Optimized the `redactPIIInObject` function in `src/lib/pii-redaction.ts` to lazily allocate the `WeakSet` instance used for tracking circular references (`seen?: WeakSet<object>`).

### Why:
Previously, a new `WeakSet` was instantiated as a default parameter value on every call to `redactPIIInObject`. This led to unnecessary object allocations and GC overhead when processing primitives, strings, or early quick-returns, which constitute the majority of logged elements.

### Impact:
Reduces memory allocation and GC overhead in the high-frequency log redaction paths, making log processing more efficient. All 1700+ tests pass with zero regressions.

---
*PR created automatically by Jules for task [10933753566323237539](https://jules.google.com/task/10933753566323237539) started by @cpa03*