### PR TITLE
🛡️ Sentinel: Refactor admin auth to use side-effect-free lazy environment getters

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,6 @@
+# Sentinel Security Journal — Critical Learnings
+
+## 2026-07-18 - Side-Effect-Free Module Loading & Lazy Auth Environment Getters
+**Vulnerability:** Evaluating sensitive configuration like `ADMIN_API_KEY` and emitting log warnings at module-level/top-level load causes side-effects. This leads to environment validation leaks, console spam during dynamic page compilation, and severe build failures in strict side-effect-free serverless environments (such as Cloudflare Workers or Edge runtime).
+**Learning:** Next.js and Edge/Cloudflare Workers run top-level module code during static page rendering, optimization steps, and build checks. Doing direct `process.env` accesses and running active side-effects (like logging warning messages) during top-level load pollutes clean build execution contexts.
+**Prevention:** Avoid top-level module initialization that runs logging or complex evaluation. Implement lazy, cached getters like `getAdminApiKey()` and `getIsDevelopment()` guarded with safety checks (`typeof process !== 'undefined'`). Move lifecycle warning logs inside dynamic functions (e.g., `isAdminAuthenticated`) so they run exactly once on-demand.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import './.next/types/routes.d.ts';
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -7,16 +7,17 @@ import { SecurityAuditLog } from '@/lib/security/audit-log';
 import { SECURITY_ENV_KEYS, PLATFORM_ENV_KEYS } from '@/lib/config/env-keys';
 import { API_ERROR_MESSAGES } from '@/lib/config';
 
-const ADMIN_API_KEY = process.env[SECURITY_ENV_KEYS.ADMIN_API_KEY];
 const logger = createLogger('auth');
+let warnedAboutMissingKey = false;
 
-if (
-  !ADMIN_API_KEY &&
-  process.env[PLATFORM_ENV_KEYS.NODE_ENV] !== 'development'
-) {
-  logger.warn(
-    'ADMIN_API_KEY not set. Admin routes will be disabled in production.'
-  );
+function getIsDevelopment(): boolean {
+  if (typeof process === 'undefined') return false;
+  return process.env[PLATFORM_ENV_KEYS.NODE_ENV] === 'development';
+}
+
+function getAdminApiKey(): string {
+  if (typeof process === 'undefined') return '';
+  return process.env[SECURITY_ENV_KEYS.ADMIN_API_KEY] || '';
 }
 
 export interface AuthenticatedUser {
@@ -35,8 +36,17 @@ function safeEqual(a: Uint8Array, b: Uint8Array): boolean {
 }
 
 export async function isAdminAuthenticated(request: Request): Promise<boolean> {
-  if (!ADMIN_API_KEY) {
-    return process.env[PLATFORM_ENV_KEYS.NODE_ENV] === 'development';
+  const adminApiKey = getAdminApiKey();
+  const isDev = getIsDevelopment();
+
+  if (!adminApiKey) {
+    if (!isDev && !warnedAboutMissingKey) {
+      logger.warn(
+        'ADMIN_API_KEY not set. Admin routes will be disabled in production.'
+      );
+      warnedAboutMissingKey = true;
+    }
+    return isDev;
   }
 
   const authHeader = request.headers.get('authorization');
@@ -78,7 +88,7 @@ export async function isAdminAuthenticated(request: Request): Promise<boolean> {
 
     const expectedHash = await crypto.subtle.digest(
       AUTH_CONFIG.HASH_ALGORITHM,
-      encoder.encode(ADMIN_API_KEY)
+      encoder.encode(adminApiKey)
     );
     const actualHash = await crypto.subtle.digest(
       AUTH_CONFIG.HASH_ALGORITHM,

--- a/src/lib/config/environment.ts
+++ b/src/lib/config/environment.ts
@@ -7,9 +7,9 @@
  * with the logger module (logger → pii-redaction → config/constants).
  */
 
-export const isDevelopment = process.env.NODE_ENV === 'development';
-export const isProduction = process.env.NODE_ENV === 'production';
-export const isTest = process.env.NODE_ENV === 'test';
+export const isDevelopment = typeof process !== 'undefined' && process.env.NODE_ENV === 'development';
+export const isProduction = typeof process !== 'undefined' && process.env.NODE_ENV === 'production';
+export const isTest = typeof process !== 'undefined' && process.env.NODE_ENV === 'test';
 
 /**
  * Type-safe environment variable loader


### PR DESCRIPTION
This change refactors the administration authentication verification module to remove top-level evaluation of ADMIN_API_KEY and the associated module-level side-effect warnings. By introducing lazy environment getters with proper runtime environment guards, this change avoids production console log warning pollution during page static compilation, making the module fully compatible with strict side-effect-free serverless environments (like Cloudflare Workers and Edge runtimes). It also documents the security and environment learnings in the Sentinel journal.

---
*PR created automatically by Jules for task [15905760642626975286](https://jules.google.com/task/15905760642626975286) started by @cpa03*