### PR TITLE
🛡️ Sentinel: Mitigate Timing-Attack Side-Channel in Rate Limiting

### DIFF
--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -11,7 +11,7 @@ import {
 import { HTTP_HEADERS } from './config/http';
 import { ENV_ACCESSORS } from './config/env-keys';
 import { generateRequestId } from './errors';
-import { simpleHash } from './security/crypto';
+import { simpleHash, timingSafeEqualStrings } from './security/crypto';
 import { TIME_CONVERSIONS } from './config/modular-constants';
 import { API_ERROR_MESSAGES } from './config/error-messages';
 
@@ -67,7 +67,9 @@ function extractUserIdFromRequest(request: Request): string | null {
 
     if (
       isDev ||
-      (internalSecret && expectedSecret && internalSecret === expectedSecret)
+      (internalSecret &&
+        expectedSecret &&
+        timingSafeEqualStrings(internalSecret, expectedSecret))
     ) {
       return xUserId.trim() || null;
     }
@@ -119,7 +121,9 @@ function determineUserRole(request: Request, userId: string | null): UserRole {
   const expectedSecret = ENV_ACCESSORS.SECURITY.INTERNAL_API_SECRET();
   const isTrusted =
     isDev ||
-    (internalSecret && expectedSecret && internalSecret === expectedSecret);
+    (internalSecret &&
+      expectedSecret &&
+      timingSafeEqualStrings(internalSecret, expectedSecret));
 
   if (isTrusted) {
     const tierHeader = request.headers.get('x-user-tier');

--- a/src/lib/security/crypto.ts
+++ b/src/lib/security/crypto.ts
@@ -80,6 +80,38 @@ export function generateId(): string {
 }
 
 /**
+ * Timing-safe string comparison to prevent timing attacks.
+ * This is compatible with both Node.js and Edge/Browser/Cloudflare Worker runtimes,
+ * as it does not rely on any platform-specific Node modules.
+ *
+ * It uses a constant-time loop over the characters of both strings.
+ *
+ * @param a - First string
+ * @param b - Second string
+ * @returns true if the strings are identical, false otherwise
+ */
+export function timingSafeEqualStrings(a: string, b: string): boolean {
+  if (typeof a !== 'string' || typeof b !== 'string') {
+    return false;
+  }
+
+  const aLen = a.length;
+  const bLen = b.length;
+  let result = 0;
+
+  // We loop over the maximum length to ensure the execution time
+  // depends primarily on the length of the inputs, not where they differ.
+  const maxLen = Math.max(aLen, bLen);
+  for (let i = 0; i < maxLen; i++) {
+    const charA = i < aLen ? a.charCodeAt(i) : 0;
+    const charB = i < bLen ? b.charCodeAt(i) : 0;
+    result |= charA ^ charB;
+  }
+
+  return result === 0 && aLen === bLen;
+}
+
+/**
  * Generate a simple, deterministic 32-bit hash for a string.
  * Uses a hardened djb2 algorithm with bitwise OR wrapping to maintain
  * 32-bit precision across all environments.

--- a/tests/security/crypto-fallback.test.ts
+++ b/tests/security/crypto-fallback.test.ts
@@ -1,4 +1,4 @@
-import { generateId, secureRandom } from '@/lib/security/crypto';
+import { generateId, secureRandom, timingSafeEqualStrings } from '@/lib/security/crypto';
 
 describe('generateId Fallback', () => {
   let originalCrypto: unknown;
@@ -25,5 +25,36 @@ describe('generateId Fallback', () => {
     });
 
     expect(() => generateId()).toThrow(/CRITICAL SECURITY/);
+  });
+});
+
+describe('timingSafeEqualStrings', () => {
+  it('should return true for identical strings', () => {
+    expect(timingSafeEqualStrings('hello', 'hello')).toBe(true);
+    expect(timingSafeEqualStrings('', '')).toBe(true);
+    expect(timingSafeEqualStrings('a', 'a')).toBe(true);
+    expect(timingSafeEqualStrings('super-secret-key-123!', 'super-secret-key-123!')).toBe(true);
+  });
+
+  it('should return false for different strings of the same length', () => {
+    expect(timingSafeEqualStrings('hello', 'world')).toBe(false);
+    expect(timingSafeEqualStrings('abc', 'abd')).toBe(false);
+    expect(timingSafeEqualStrings('abc', 'xbc')).toBe(false);
+  });
+
+  it('should return false for strings of different lengths', () => {
+    expect(timingSafeEqualStrings('hello', 'hello-world')).toBe(false);
+    expect(timingSafeEqualStrings('hello-world', 'hello')).toBe(false);
+    expect(timingSafeEqualStrings('a', '')).toBe(false);
+    expect(timingSafeEqualStrings('', 'b')).toBe(false);
+  });
+
+  it('should return false if any parameter is not a string', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(timingSafeEqualStrings(null as any, 'hello')).toBe(false);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(timingSafeEqualStrings('hello', undefined as any)).toBe(false);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(timingSafeEqualStrings(123 as any, 123 as any)).toBe(false);
   });
 });


### PR DESCRIPTION
Identified a side-channel timing-attack vulnerability where internal secret comparisons used standard '===' equality. Solved this by implementing a platform-agnostic, edge-compatible 'timingSafeEqualStrings' utility function in 'src/lib/security/crypto.ts' and utilizing it for all internal API secret comparisons in 'src/lib/rate-limit.ts'. Added comprehensive unit tests in 'tests/security/crypto-fallback.test.ts'. All tests pass.

---
*PR created automatically by Jules for task [7105960476786327891](https://jules.google.com/task/7105960476786327891) started by @cpa03*