### PR TITLE
🎨 Palette: Add focus-visible ring and descriptive ARIA instructions to Referral URL code block

### DIFF
--- a/src/components/ReferralLink.tsx
+++ b/src/components/ReferralLink.tsx
@@ -9,7 +9,6 @@ import {
   SVG_VIEWBOX,
   REFERRAL_LINK_LABELS,
   GRAY_CLASSES,
-  FOCUS_RING_PATTERNS,
   WHITE_BG_PATTERNS,
 } from '@/lib/config';
 import { triggerHapticFeedback } from '@/lib/utils';
@@ -124,7 +123,8 @@ export default function ReferralLink({
               onKeyDown={handleCodeKeyDown}
               tabIndex={0}
               title={REFERRAL_LINK_LABELS.CODE_TITLE}
-              className={`flex-1 min-w-0 px-3 py-2 ${WHITE_BG_PATTERNS.DEFAULT} border border-primary-200 rounded-md text-sm text-primary-800 truncate font-mono cursor-pointer ${GRAY_CLASSES.HOVER_BG_50} ${FOCUS_RING_PATTERNS.DEFAULT} transition-colors duration-200`}
+              aria-label={`${referralUrl}. Press Space or Enter to select the link.`}
+              className={`flex-1 min-w-0 px-3 py-2 ${WHITE_BG_PATTERNS.DEFAULT} border border-primary-200 rounded-md text-sm text-primary-800 truncate font-mono cursor-pointer ${GRAY_CLASSES.HOVER_BG_50} transition-all duration-200 outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2`}
             >
               {referralUrl}
             </code>

--- a/tests/ReferralLink.test.tsx
+++ b/tests/ReferralLink.test.tsx
@@ -24,14 +24,22 @@ describe('ReferralLink', () => {
     jest.clearAllMocks();
   });
 
-  it('renders the referral title, description, and link correctly', () => {
+  it('renders the referral title, description, and link correctly with focus-visible and aria attributes', () => {
     render(<ReferralLink referralCode="testcode123" />);
 
     expect(screen.getByText(/Share Your Referral Link/i)).toBeInTheDocument();
     expect(
       screen.getByText(/Invite friends and earn rewards when they sign up!/i)
     ).toBeInTheDocument();
-    expect(screen.getByText(/signup\?ref=testcode123/i)).toBeInTheDocument();
+
+    const codeElement = screen.getByText(/signup\?ref=testcode123/i);
+    expect(codeElement).toBeInTheDocument();
+    expect(codeElement).toHaveAttribute(
+      'aria-label',
+      'http://localhost/signup?ref=testcode123. Press Space or Enter to select the link.'
+    );
+    expect(codeElement.className).toContain('focus-visible:ring-2');
+    expect(codeElement.className).toContain('focus-visible:ring-primary-500');
   });
 
   it('selects the entire code container content on click', () => {


### PR DESCRIPTION
Added a visible focus-visible ring outline and clear keyboard selection instructions (aria-label) to the referral link code block in `ReferralLink.tsx`. Also updated `tests/ReferralLink.test.tsx` to assert correct class names and ARIA attributes.

---
*PR created automatically by Jules for task [962347420665772022](https://jules.google.com/task/962347420665772022) started by @cpa03*