### PR TITLE
🎨 Palette: Upfront password requirements checklist to eliminate CLS

### DIFF
--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -585,7 +585,7 @@ export default function SignupPage() {
 
             <CapsLockWarning isOn={isPasswordCapsLockOn} />
 
-            {password && <PasswordRequirementsChecklist password={password} />}
+            <PasswordRequirementsChecklist password={password} showWhenEmpty={true} />
 
             {password && <PasswordStrengthIndicator password={password} />}
 

--- a/tests/PasswordRequirementsChecklist.test.tsx
+++ b/tests/PasswordRequirementsChecklist.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { PasswordRequirementsChecklist } from '@/components/PasswordRequirementsChecklist';
+
+describe('PasswordRequirementsChecklist', () => {
+  it('returns null when password is empty and showWhenEmpty is false', () => {
+    const { container } = render(
+      <PasswordRequirementsChecklist password="" showWhenEmpty={false} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders correctly when password is empty and showWhenEmpty is true', () => {
+    render(<PasswordRequirementsChecklist password="" showWhenEmpty={true} />);
+
+    // group with group role should be in the document
+    const group = screen.getByRole('group');
+    expect(group).toBeInTheDocument();
+    expect(group).toHaveAttribute('aria-label', 'Password requirements: 0 of 5 met');
+
+    // Should render the progress bar
+    const progressbar = screen.getByRole('progressbar');
+    expect(progressbar).toBeInTheDocument();
+    expect(progressbar).toHaveAttribute('aria-valuenow', '0');
+
+    // All requirement items should be rendered as not met
+    const lengthItem = screen.getByLabelText(/At least 8 characters: not met/i);
+    expect(lengthItem).toBeInTheDocument();
+
+    const uppercaseItem = screen.getByLabelText(/Contains uppercase letter: not met/i);
+    expect(uppercaseItem).toBeInTheDocument();
+
+    const lowercaseItem = screen.getByLabelText(/Contains lowercase letter: not met/i);
+    expect(lowercaseItem).toBeInTheDocument();
+
+    const numberItem = screen.getByLabelText(/Contains a number: not met/i);
+    expect(numberItem).toBeInTheDocument();
+
+    const specialItem = screen.getByLabelText(/Contains special character \(!@#\$%\^&\*\): not met/i);
+    expect(specialItem).toBeInTheDocument();
+  });
+
+  it('correctly updates met status when partial password is provided', () => {
+    // "Ab" has uppercase, lowercase, length = 2
+    render(<PasswordRequirementsChecklist password="Ab" showWhenEmpty={true} />);
+
+    const group = screen.getByRole('group');
+    expect(group).toHaveAttribute('aria-label', 'Password requirements: 2 of 5 met');
+
+    const progressbar = screen.getByRole('progressbar');
+    expect(progressbar).toHaveAttribute('aria-valuenow', '2');
+
+    // Met requirements: uppercase, lowercase
+    expect(screen.getByLabelText(/Contains uppercase letter: met/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Contains lowercase letter: met/i)).toBeInTheDocument();
+
+    // Unmet requirements: length, number, special
+    expect(screen.getByLabelText(/At least 8 characters: not met/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Contains a number: not met/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Contains special character \(!@#\$%\^&\*\): not met/i)).toBeInTheDocument();
+  });
+
+  it('shows success and celebration when all requirements are met', () => {
+    // "Ab1!cdef" has length=8, uppercase, lowercase, number, special
+    render(<PasswordRequirementsChecklist password="Ab1!cdef" showWhenEmpty={true} />);
+
+    const group = screen.getByRole('group');
+    expect(group).toHaveAttribute('aria-label', 'Password requirements: 5 of 5 met');
+
+    const progressbar = screen.getByRole('progressbar');
+    expect(progressbar).toHaveAttribute('aria-valuenow', '5');
+
+    // All should be met
+    expect(screen.getByLabelText(/At least 8 characters: met/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Contains uppercase letter: met/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Contains lowercase letter: met/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Contains a number: met/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Contains special character \(!@#\$%\^&\*\): met/i)).toBeInTheDocument();
+
+    // Success status text should be rendered
+    const statusText = screen.getByRole('status');
+    expect(statusText).toHaveTextContent(/All requirements met/i);
+  });
+});


### PR DESCRIPTION
🎨 Palette: Always render password requirements checklist on empty inputs to prevent layout jumps and guide user input.

💡 What: Changed password requirements checklist rendering on the Signup page from conditional mounting (only when password has text) to rendering it from the start with `showWhenEmpty={true}`.
🎯 Why:
1. Prevents a jarring Cumulative Layout Shift (CLS) that occurs as soon as the user starts typing, which pushes form controls, password strength bars, and action buttons down the page.
2. Enhances cognitive accessibility by making complexity criteria clear and upfront, so users know exact requirements before they type.

♿ Accessibility & UX:
- Eliminates layout shifts (CLS).
- Provides upfront, visible guidelines.
- Progressively ticks off criteria and displays a friendly success message when all items are checked.
- Added comprehensive Jest tests to verify empty states, met/unmet states, progress counts, and completion states.

---
*PR created automatically by Jules for task [4465151831506385125](https://jules.google.com/task/4465151831506385125) started by @cpa03*