### PR TITLE
🛡️ Sentinel: Prevent HTML Sanitization Bypasses via Protocol Obfuscation

### DIFF
--- a/docs/security/sentinel.md
+++ b/docs/security/sentinel.md
@@ -17,3 +17,9 @@ This document tracks security vulnerabilities discovered and lessons learned to 
 **Vulnerability:** The PII redaction utility and health check endpoint were missing common patterns for modern secrets (like AWS secret keys containing Base64 characters) and highly sensitive payment-related fields (CVV, CVC, PIN).
 **Learning:** Standard alphanumeric regex patterns ([a-zA-Z0-9]) fail to capture many types of secrets that use full Base64 sets or other special characters. Additionally, centralized redaction lists must be kept in sync across diagnostic and logging utilities to prevent inconsistent data exposure.
 **Prevention:** Use comprehensive regex patterns that include Base64 characters (`/`, `+`, `=`) for API key redaction. Centralize sensitive keyword lists used by both health checks and log redaction utilities to ensure consistent protection across the application.
+
+## 2026-07-22 - HTML Sanitization Bypass via Protocol Obfuscation
+
+**Vulnerability:** The HTML sanitization regex patterns was vulnerable to bypasses using whitespaces (tabs, newlines, carriage returns, or vertical tabs) or control characters inserted within sensitive protocols like `javascript:`, `vbscript:`, `livescript:`, and `data:`. Browsers naturally strip or ignore these characters in URLs, but standard strict string matches or simple regexes fail to match them, leaving the payload active.
+**Learning:** Custom, regex-based sanitizers are highly prone to protocol-obfuscation bypasses because they expect contiguous, clean strings. Obfuscation techniques take advantage of the difference between how regex engines scan strings and how browser URL/HTML parsers normalize and decode attributes before executing them.
+**Prevention:** Always write defensive regexes that account for optional whitespace or control characters (`[\s\x00-\x1F]*`) inside protocol names when building custom sanitizers, or prefer robust, standard parser-based sanitizers (like DOMPurify) when applicable.

--- a/src/lib/config/validation.ts
+++ b/src/lib/config/validation.ts
@@ -74,8 +74,8 @@ export const SANITIZATION_CONFIG = {
   REGEX: {
     SCRIPT: /<script[^>]*>[\s\S]*?<\/script>/gi,
     EVENT_HANDLER: /[\s/]*on\w+\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]*)/gi,
-    JAVASCRIPT_PROTOCOL: /(?:javascript|vbscript|livescript)\s*:/gi,
-    DATA_URI: /data\s*:\s*(?:text\/html|image\/svg\+xml)/gi,
+    JAVASCRIPT_PROTOCOL: /(?:j[\s\x00-\x1F]*a[\s\x00-\x1F]*v[\s\x00-\x1F]*a[\s\x00-\x1F]*s[\s\x00-\x1F]*c[\s\x00-\x1F]*r[\s\x00-\x1F]*i[\s\x00-\x1F]*p[\s\x00-\x1F]*t|v[\s\x00-\x1F]*b[\s\x00-\x1F]*s[\s\x00-\x1F]*c[\s\x00-\x1F]*r[\s\x00-\x1F]*i[\s\x00-\x1F]*p[\s\x00-\x1F]*t|l[\s\x00-\x1F]*i[\s\x00-\x1F]*v[\s\x00-\x1F]*e[\s\x00-\x1F]*s[\s\x00-\x1F]*c[\s\x00-\x1F]*r[\s\x00-\x1F]*i[\s\x00-\x1F]*p[\s\x00-\x1F]*t)[\s\x00-\x1F]*:/gi,
+    DATA_URI: /d[\s\x00-\x1F]*a[\s\x00-\x1F]*t[\s\x00-\x1F]*a[\s\x00-\x1F]*:[\s\x00-\x1F]*(?:text\/html|image\/svg\+xml)/gi,
     STYLE: /[\s/]*style\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]*)/gi,
   },
 

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -241,10 +241,10 @@ const HTML_ESCAPE_REGEX = new RegExp(
 /**
  * Fast-path trigger regex to identify strings that likely need no sanitization.
  * Checks for: <, >, &, ", ', / or any common event handler pattern (on...),
- * or dangerous protocols (javascript:, data:text/html).
+ * or dangerous protocols (javascript:, data:text/html) including obfuscated versions.
  */
 const NEEDS_SANITIZATION_REGEX =
-  /[<>&"'/`]|\bon\w+\s*=|[\s/]*style\s*=|(?:\b|[^a-z0-9])(?:javascript|vbscript|livescript)\s*:|data\s*:\s*(?:text\/html|image\/svg\+xml)/i;
+  /[<>&"'/`]|\bon\w+\s*=|[\s/]*style\s*=|(?:\b|[^a-z0-9])(?:j[\s\x00-\x1F]*a[\s\x00-\x1F]*v[\s\x00-\x1F]*a[\s\x00-\x1F]*s[\s\x00-\x1F]*c[\s\x00-\x1F]*r[\s\x00-\x1F]*i[\s\x00-\x1F]*p[\s\x00-\x1F]*t|v[\s\x00-\x1F]*b[\s\x00-\x1F]*s[\s\x00-\x1F]*c[\s\x00-\x1F]*r[\s\x00-\x1F]*i[\s\x00-\x1F]*p[\s\x00-\x1F]*t|l[\s\x00-\x1F]*i[\s\x00-\x1F]*v[\s\x00-\x1F]*e[\s\x00-\x1F]*s[\s\x00-\x1F]*c[\s\x00-\x1F]*r[\s\x00-\x1F]*i[\s\x00-\x1F]*p[\s\x00-\x1F]*t)[\s\x00-\x1F]*:|d[\s\x00-\x1F]*a[\s\x00-\x1F]*t[\s\x00-\x1F]*a[\s\x00-\x1F]*:[\s\x00-\x1F]*(?:text\/html|image\/svg\+xml)/i;
 
 /**
  * Sanitizes HTML content by removing script tags and escaping HTML entities

--- a/tests/security/sanitize-bypass.test.ts
+++ b/tests/security/sanitize-bypass.test.ts
@@ -37,4 +37,35 @@ describe('sanitizeHtml Security Bypasses', () => {
     const sanitized = sanitizeHtml(input);
     expect(sanitized.toLowerCase()).not.toContain('onload');
   });
+
+  it('should catch obfuscated javascript protocols with whitespace and control characters', () => {
+    const inputs = [
+      'java\nscript:alert(1)',
+      'java\tscript:alert(1)',
+      'java\rscript:alert(1)',
+      'java\u0000script:alert(1)',
+      'j\ta\nv\ra\ts\nc\rr\ti\np\rt:alert(1)',
+    ];
+
+    for (const input of inputs) {
+      const sanitized = sanitizeHtml(input);
+      expect(sanitized).not.toBe(input);
+      expect(sanitized).toContain('[REDACTED_PROTOCOL]');
+    }
+  });
+
+  it('should catch obfuscated data protocols with whitespace and control characters', () => {
+    const inputs = [
+      'da\nta:text/html,abc',
+      'da\tta:text/html,abc',
+      'da\rta:text/html,abc',
+      'da\u0000ta:text/html,abc',
+    ];
+
+    for (const input of inputs) {
+      const sanitized = sanitizeHtml(input);
+      expect(sanitized).not.toBe(input);
+      expect(sanitized).toContain('[REDACTED_DATA_URI]');
+    }
+  });
 });


### PR DESCRIPTION
### 🚨 Severity: HIGH (Cross-Site Scripting bypass)

### 💡 Vulnerability:
The server-side regex-based HTML sanitizer (`sanitizeHtml`) was vulnerable to bypasses using whitespace or control-character obfuscation (e.g. `java\nscript:`, `java\tscript:`, or `da\nta:text/html`). Browsers naturally normalize these characters inside hrefs and attributes, but standard contiguous regex matches would ignore them, failing to neutralize the dangerous payloads.

### 🔧 Fix:
Enhanced the `NEEDS_SANITIZATION_REGEX` in `src/lib/validation.ts` and the `REGEX` patterns (`JAVASCRIPT_PROTOCOL` and `DATA_URI`) in `src/lib/config/validation.ts` to recognize and redact protocols even when obfuscated with whitespaces or control characters (`[\s\x00-\x1F]*`).

### ✅ Verification:
- Added comprehensive unit tests in `tests/security/sanitize-bypass.test.ts`.
- Ran and verified that all security test suites pass.
- Verified lint checks and compiled production builds successfully with zero errors.

---
*PR created automatically by Jules for task [13646251723855516657](https://jules.google.com/task/13646251723855516657) started by @cpa03*