### PR TITLE
🎨 Palette: add Ctrl+C / Cmd+C focused shortcut support for CopyButton

### DIFF
--- a/src/components/CopyButton.tsx
+++ b/src/components/CopyButton.tsx
@@ -76,6 +76,17 @@ const CopyButtonComponent = function CopyButton({
     copy(textToCopy);
   }, [copy, textToCopy]);
 
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLButtonElement>) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === 'c') {
+        e.preventDefault();
+        e.stopPropagation();
+        handleCopy();
+      }
+    },
+    [handleCopy]
+  );
+
   const baseClasses = `
     inline-flex items-center justify-center gap-2
     font-medium ${TRANSITION_CLASSES.DEFAULT} ease-out transform
@@ -123,6 +134,7 @@ const CopyButtonComponent = function CopyButton({
         <span className="relative inline-flex">
           <button
             onClick={handleCopy}
+            onKeyDown={handleKeyDown}
             className={`${baseClasses} ${variantClasses[variant]} ${glowClass} ${className}`}
             aria-label={ariaLabel}
             type="button"

--- a/tests/CopyButton.test.tsx
+++ b/tests/CopyButton.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import CopyButton from '@/components/CopyButton';
+
+// Mock clipboard API
+const mockWriteText = jest.fn();
+Object.defineProperty(navigator, 'clipboard', {
+  value: {
+    writeText: mockWriteText,
+  },
+  writable: true,
+});
+
+describe('CopyButton Keyboard Shortcuts & Functionality', () => {
+  beforeEach(() => {
+    mockWriteText.mockClear();
+  });
+
+  it('renders CopyButton with default label', () => {
+    render(<CopyButton textToCopy="Hello World" />);
+    const button = screen.getByRole('button');
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveTextContent('Copy');
+  });
+
+  it('copies text to clipboard on click', async () => {
+    render(<CopyButton textToCopy="Hello World" />);
+    const button = screen.getByRole('button');
+
+    await act(async () => {
+      fireEvent.click(button);
+    });
+
+    expect(mockWriteText).toHaveBeenCalledWith('Hello World');
+  });
+
+  it('copies text to clipboard when focused and pressing Ctrl+C', async () => {
+    render(<CopyButton textToCopy="Hello World" />);
+    const button = screen.getByRole('button');
+    button.focus();
+
+    await act(async () => {
+      fireEvent.keyDown(button, { key: 'c', ctrlKey: true });
+    });
+
+    expect(mockWriteText).toHaveBeenCalledWith('Hello World');
+  });
+
+  it('copies text to clipboard when focused and pressing Cmd+C (metaKey)', async () => {
+    render(<CopyButton textToCopy="Hello World" />);
+    const button = screen.getByRole('button');
+    button.focus();
+
+    await act(async () => {
+      fireEvent.keyDown(button, { key: 'c', metaKey: true });
+    });
+
+    expect(mockWriteText).toHaveBeenCalledWith('Hello World');
+  });
+
+  it('does not copy text if pressing C without modifier keys', async () => {
+    render(<CopyButton textToCopy="Hello World" />);
+    const button = screen.getByRole('button');
+    button.focus();
+
+    await act(async () => {
+      fireEvent.keyDown(button, { key: 'c' });
+    });
+
+    expect(mockWriteText).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
🎨 **Palette: UX/Accessibility - Focused CopyButton Hotkey Integration**

### 💡 What:
- Implemented a localized keyboard event handler (`onKeyDown`) on the main `<button>` element inside `src/components/CopyButton.tsx`.
- Intercepts the key combination `(e.metaKey || e.ctrlKey) && e.key === 'c'` to trigger programmatic clipboard copying when the button has active focus.
- Automatically prevents default actions and stops propagation when triggered to maintain perfect UI boundaries.

### 🎯 Why:
- **Consistency & Power-user Experience:** Tooltips in `CopyButton` advertise the `⌘C` / `Ctrl+C` shortcut, but without focused keydown support, pressing the shortcut had no programmatic effect.
- **Selection Safety:** By scoping the keydown listener exclusively to the focused element, we prevent any collision with browser text selection (global copying) elsewhere on the screen.

### ♿ Accessibility & Micro-UX:
- Seamless screen reader and keyboard-only support.
- Integrated beautifully with haptic feedback, checkmark animations, and localized status announcements.
- Added comprehensive unit tests in `tests/CopyButton.test.tsx` verifying default rendering, click behavior, and keyboard shortcuts (`Ctrl+C` and `Cmd+C`) under active focus.
- Recorded critical UX/A11y learnings in `.jules/palette.md`.

---
*PR created automatically by Jules for task [8309334010805549595](https://jules.google.com/task/8309334010805549595) started by @cpa03*