### PR TITLE
⚡ Bolt: wrap ReferralLink in React.memo for rendering optimization

### DIFF
--- a/src/components/ReferralLink.tsx
+++ b/src/components/ReferralLink.tsx
@@ -6,6 +6,7 @@ import React, {
   useState,
   useRef,
   useEffect,
+  memo,
 } from 'react';
 import CopyButton from './CopyButton';
 import Tooltip from './Tooltip';
@@ -48,7 +49,7 @@ export interface ReferralLinkProps {
  * @example
  * <ReferralLink referralCode="user123" />
  */
-export default function ReferralLink({
+function ReferralLinkComponent({
   referralCode,
   baseUrl = typeof window !== 'undefined'
     ? window.location.origin
@@ -207,3 +208,6 @@ export default function ReferralLink({
     </div>
   );
 }
+
+const ReferralLink = memo(ReferralLinkComponent);
+export default ReferralLink;


### PR DESCRIPTION
This PR wraps the ReferralLink component in React.memo to optimize rendering performance. Since ReferralLink is relatively static for a given referralCode and baseUrl, memoizing it avoids virtual DOM reconciliation overhead and prevents redundant growth analytics view events from triggering on parent component re-renders.

---
*PR created automatically by Jules for task [15915194406363080741](https://jules.google.com/task/15915194406363080741) started by @cpa03*