### PR TITLE
🎨 Palette: Prevent EmailButton keyboard shortcut hijacking on active inputs

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import './.next/types/routes.d.ts';
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/components/EmailButton.tsx
+++ b/src/components/EmailButton.tsx
@@ -19,6 +19,7 @@ import {
 } from '@/lib/config';
 import { EMAIL_BUTTON_LABELS } from '@/lib/config/component-labels';
 import { usePrefersReducedMotion } from '@/hooks/usePrefersReducedMotion';
+import { isFocusedOnInput } from '@/lib/dom-utils';
 
 export interface EmailButtonProps {
   ideaTitle: string;
@@ -117,8 +118,10 @@ const EmailButtonComponent = function EmailButton({
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if ((e.metaKey || e.ctrlKey) && e.key === 'e') {
-        e.preventDefault();
-        handleEmailClick();
+        if (!isFocusedOnInput(e.target)) {
+          e.preventDefault();
+          handleEmailClick();
+        }
       }
     };
 

--- a/tests/EmailButton.test.tsx
+++ b/tests/EmailButton.test.tsx
@@ -1,0 +1,119 @@
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import EmailButton from '@/components/EmailButton';
+
+// Mock window.open
+const mockOpen = jest.fn();
+const originalOpen = window.open;
+
+describe('EmailButton Keyboard Shortcuts & Functionality', () => {
+  beforeAll(() => {
+    window.open = mockOpen;
+  });
+
+  afterAll(() => {
+    window.open = originalOpen;
+  });
+
+  beforeEach(() => {
+    mockOpen.mockClear();
+  });
+
+  it('renders EmailButton with default label', () => {
+    render(<EmailButton ideaTitle="My Idea" ideaContent="Flow Content" />);
+    const button = screen.getByRole('button');
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveTextContent('Email to Self');
+  });
+
+  it('opens email client with mailto link on click', async () => {
+    render(<EmailButton ideaTitle="My Idea" ideaContent="Flow Content" />);
+    const button = screen.getByRole('button');
+
+    await act(async () => {
+      fireEvent.click(button);
+    });
+
+    expect(mockOpen).toHaveBeenCalled();
+    const mailtoUrl = mockOpen.mock.calls[0][0];
+    expect(mailtoUrl).toContain('mailto:');
+
+    const decodedUrl = decodeURIComponent(mailtoUrl);
+    expect(decodedUrl).toContain('subject=My IdeaFlow Blueprint: My Idea');
+    expect(decodedUrl).toContain('Summary:\nFlow Content');
+  });
+
+  it('opens email client via Ctrl+E keyboard shortcut when not in input', async () => {
+    render(<EmailButton ideaTitle="My Idea" ideaContent="Flow Content" />);
+
+    await act(async () => {
+      fireEvent.keyDown(document, { key: 'e', ctrlKey: true });
+    });
+
+    expect(mockOpen).toHaveBeenCalled();
+  });
+
+  it('opens email client via Cmd+E keyboard shortcut when not in input', async () => {
+    render(<EmailButton ideaTitle="My Idea" ideaContent="Flow Content" />);
+
+    await act(async () => {
+      fireEvent.keyDown(document, { key: 'e', metaKey: true });
+    });
+
+    expect(mockOpen).toHaveBeenCalled();
+  });
+
+  it('does not open email client via Ctrl+E when typing in an input element', async () => {
+    render(
+      <div>
+        <input data-testid="test-input" type="text" />
+        <EmailButton ideaTitle="My Idea" ideaContent="Flow Content" />
+      </div>
+    );
+
+    const input = screen.getByTestId('test-input');
+    input.focus();
+
+    await act(async () => {
+      fireEvent.keyDown(input, { key: 'e', ctrlKey: true });
+    });
+
+    expect(mockOpen).not.toHaveBeenCalled();
+  });
+
+  it('does not open email client via Ctrl+E when typing in a textarea element', async () => {
+    render(
+      <div>
+        <textarea data-testid="test-textarea" />
+        <EmailButton ideaTitle="My Idea" ideaContent="Flow Content" />
+      </div>
+    );
+
+    const textarea = screen.getByTestId('test-textarea');
+    textarea.focus();
+
+    await act(async () => {
+      fireEvent.keyDown(textarea, { key: 'e', ctrlKey: true });
+    });
+
+    expect(mockOpen).not.toHaveBeenCalled();
+  });
+
+  it('calls the onEmailSent callback on successful trigger', async () => {
+    const onEmailSentMock = jest.fn();
+    render(
+      <EmailButton
+        ideaTitle="My Idea"
+        ideaContent="Flow Content"
+        onEmailSent={onEmailSentMock}
+      />
+    );
+    const button = screen.getByRole('button');
+
+    await act(async () => {
+      fireEvent.click(button);
+    });
+
+    expect(onEmailSentMock).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
🎨 Added isFocusedOnInput(e.target) validation check to EmailButton's global keydown keyboard listener. This prevents the Ctrl+E/Cmd+E key combinations from triggering the Send-to-Self email client when users are actively typing inside text inputs, textareas, or content-editable elements, protecting user focus and input flow. Also added a robust and comprehensive Jest unit test suite tests/EmailButton.test.tsx covering all click and shortcut states.

---
*PR created automatically by Jules for task [9347413797891203985](https://jules.google.com/task/9347413797891203985) started by @cpa03*