### PR TITLE
🎨 Palette: Add Tooltip and Esc shortcut to Onboarding tour Skip button

### DIFF
--- a/src/components/UserOnboarding.tsx
+++ b/src/components/UserOnboarding.tsx
@@ -35,6 +35,7 @@ import { CONTAINER_WIDTH_CLASSES } from '@/lib/config/ui-dimensions';
 import { triggerHapticFeedback } from '@/lib/utils';
 import { isFocusedOnInput } from '@/lib/dom-utils';
 import { usePrefersReducedMotion } from '@/hooks/usePrefersReducedMotion';
+import Tooltip from './Tooltip';
 
 /**
  * Onboarding Tour Steps
@@ -408,26 +409,30 @@ export default function UserOnboarding() {
         />
 
         {/* Close button */}
-        <button
-          onClick={handleSkip}
-          className={`absolute top-3 right-3 ${TEXT_COLORS.MUTED_DARK} ${TEXT_COLORS.HOVER_SECONDARY} ${TRANSITION_CLASSES.COLOR} p-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 rounded-md`}
-          aria-label={USER_ONBOARDING_LABELS.SKIP_ARIA_LABEL}
-        >
-          <svg
-            className={ICON_SIZES.LG}
-            fill="none"
-            stroke="currentColor"
-            viewBox={SVG_VIEWBOX.STANDARD}
-            aria-hidden="true"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={SVG_STROKE_WIDTHS.STANDARD}
-              d="M6 18L18 6M6 6l12 12"
-            />
-          </svg>
-        </button>
+        <div className="absolute top-3 right-3">
+          <Tooltip content="Skip tour" shortcut={['Esc']} position="bottom">
+            <button
+              onClick={handleSkip}
+              className={`${TEXT_COLORS.MUTED_DARK} ${TEXT_COLORS.HOVER_SECONDARY} ${TRANSITION_CLASSES.COLOR} p-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 rounded-md`}
+              aria-label={USER_ONBOARDING_LABELS.SKIP_ARIA_LABEL}
+            >
+              <svg
+                className={ICON_SIZES.LG}
+                fill="none"
+                stroke="currentColor"
+                viewBox={SVG_VIEWBOX.STANDARD}
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={SVG_STROKE_WIDTHS.STANDARD}
+                  d="M6 18L18 6M6 6l12 12"
+                />
+              </svg>
+            </button>
+          </Tooltip>
+        </div>
 
         {/* Content */}
         <div className="mt-2">

--- a/tests/UserOnboarding.test.tsx
+++ b/tests/UserOnboarding.test.tsx
@@ -1,0 +1,131 @@
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import UserOnboarding from '@/components/UserOnboarding';
+import { LOCAL_STORAGE_KEYS } from '@/lib/config/storage-keys';
+
+// Mock the analytics module
+jest.mock('@/lib/analytics', () => ({
+  trackEvent: jest.fn(),
+  ANALYTICS_EVENTS: {
+    ONBOARDING_START: 'onboarding_start',
+    ONBOARDING_COMPLETE: 'onboarding_complete',
+  },
+}));
+
+// Mock haptic feedback
+jest.mock('@/lib/utils', () => ({
+  triggerHapticFeedback: jest.fn(),
+}));
+
+const ONBOARDING_COMPLETED_KEY = LOCAL_STORAGE_KEYS.ONBOARDING_COMPLETED;
+
+// Mock standard storage
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => store[key] || null,
+    setItem: (key: string, value: string) => {
+      store[key] = value.toString();
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    },
+  };
+})();
+
+Object.defineProperty(window, 'localStorage', {
+  value: localStorageMock,
+});
+
+describe('UserOnboarding Component', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    jest.useRealTimers();
+  });
+
+  it('should render the onboarding tour to first-time visitors', async () => {
+    render(<UserOnboarding />);
+
+    // Fast-forward the delay timer
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Skip onboarding tour/i })).toBeInTheDocument();
+  });
+
+  it('should not render if user has already completed onboarding', () => {
+    window.localStorage.setItem(ONBOARDING_COMPLETED_KEY, 'true');
+    render(<UserOnboarding />);
+
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('should navigate through steps on Next button click', () => {
+    render(<UserOnboarding />);
+
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+
+    const nextButton = screen.getByRole('button', { name: /Next/i });
+    expect(nextButton).toBeInTheDocument();
+
+    // Click Next
+    act(() => {
+      fireEvent.click(nextButton);
+    });
+
+    // Check we navigated (Next button starts step 2)
+    expect(screen.getByLabelText(/Step 2 of 4/i)).toBeInTheDocument();
+  });
+
+  it('should skip the tour on close button click', () => {
+    render(<UserOnboarding />);
+
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+
+    const skipButton = screen.getByRole('button', { name: /Skip onboarding tour/i });
+    expect(skipButton).toBeInTheDocument();
+
+    act(() => {
+      fireEvent.click(skipButton);
+    });
+
+    expect(window.localStorage.getItem(ONBOARDING_COMPLETED_KEY)).toBe('true');
+  });
+
+  it('should handle keyboard navigation correctly', () => {
+    render(<UserOnboarding />);
+
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+
+    // Press Escape to Skip
+    act(() => {
+      fireEvent.keyDown(document, { key: 'Escape' });
+    });
+
+    expect(window.localStorage.getItem(ONBOARDING_COMPLETED_KEY)).toBe('true');
+  });
+});


### PR DESCRIPTION
🎨 Palette: Wrap the Guided Tour close/skip button in a Tooltip with the Esc keyboard shortcut hint.

💡 What:
- Integrated the existing `Tooltip` component to wrap the icon-only onboarding close button in `src/components/UserOnboarding.tsx`.
- Assigned `content="Skip tour"` and `shortcut={['Esc']}` to display visual shortcuts to keyboard and screen reader users.
- Wrapped the layout in an absolute-positioned container `<div className="absolute top-3 right-3">` to prevent UI layout conflicts.
- Created `tests/UserOnboarding.test.tsx` unit test suite to fully cover guided tour interaction states.

🎯 Why:
- Guided tour close/skip buttons are highly critical first-visitor interaction spots.
- Adding a Tooltip displaying the `Esc` key shortcut makes navigation extremely clear, discoverable, and elegant.
- Fits WCAG accessibility principles perfectly.

♿ Accessibility:
- Supports physical screen readers with helpful tooltip instruction and ARIA label mapping.
- Highlights clear keyboard shortcut discovery for power users.

---
*PR created automatically by Jules for task [11391757425268010166](https://jules.google.com/task/11391757425268010166) started by @cpa03*