### PR TITLE
🛡️ Sentinel: Skip CSRF on CSP Report API Endpoint

### DIFF
--- a/docs/security/sentinel.md
+++ b/docs/security/sentinel.md
@@ -35,3 +35,9 @@ This document tracks security vulnerabilities discovered and lessons learned to 
 **Vulnerability:** The local `safeEqual` comparison function in `src/lib/auth.ts` returned `false` immediately on length mismatches before checking byte contents. While SHA-256 hashes are of a fixed size, this early return pattern leaks length/format details via a timing side-channel and represents an insecure coding pattern.
 **Learning:** Handcrafted comparison algorithms often inadvertently prioritize efficiency over constant-time security constraints. Even when input sizes are expected to be fixed, early-returning short circuits allow timing leaks.
 **Prevention:** Always use a platform-agnostic, constant-time comparison helper (such as `timingSafeEqualArrays`) that iterates across the maximum of both inputs' lengths to ensure uniform execution times under all circumstances.
+
+## 2026-07-31 - CSRF Blockage on Browser Out-of-Band Security Reporting (CSP Reports)
+
+**Vulnerability:** The Content Security Policy violation report endpoint (`/api/csp-report`) processed incoming `POST` requests through the standard `withApiHandler` wrapper. Because `skipCSRF` was not enabled, the wrapper subjected all inbound reports to full CSRF verification, rejecting legitimate browser-level reports when security-conscious browsers omitted or modified the `Origin` or `Referer` headers.
+**Learning:** Browsers dispatch native security notifications (like CSP reports) out-of-band. Because they are not standard user-driven AJAX calls, they do not carry custom anti-csrf headers. Subjecting these telemetry routes to session/origin CSRF validation causes reports to fail silently or be blocked, degrading security audit visibility.
+**Prevention:** Always bypass CSRF origin and token validation on telemetry/auditing API endpoints (like CSP reports) that do not perform state changes or side effects on behalf of user sessions.

--- a/src/app/api/csp-report/route.ts
+++ b/src/app/api/csp-report/route.ts
@@ -1,4 +1,3 @@
-import { NextResponse } from 'next/server';
 import { createLogger } from '@/lib/logger';
 import { withApiHandler, ApiContext } from '@/lib/api-handler';
 import { STATUS_CODES } from '@/lib/config';
@@ -68,12 +67,12 @@ async function handleCSPReport(context: ApiContext): Promise<Response> {
         contentType,
       });
       // Return 204 anyway - don't block browser reporting
-      return new NextResponse(null, { status: STATUS_CODES.NO_CONTENT });
+      return new Response(null, { status: STATUS_CODES.NO_CONTENT });
     }
 
     if (!reportData?.['csp-report']) {
       logger.warn('CSP report missing csp-report field', { reportData });
-      return new NextResponse(null, { status: STATUS_CODES.NO_CONTENT });
+      return new Response(null, { status: STATUS_CODES.NO_CONTENT });
     }
 
     // Extract violation details from report
@@ -106,7 +105,7 @@ async function handleCSPReport(context: ApiContext): Promise<Response> {
     });
 
     // Return 204 No Content - browsers don't need a response
-    return new NextResponse(null, { status: STATUS_CODES.NO_CONTENT });
+    return new Response(null, { status: STATUS_CODES.NO_CONTENT });
   } catch (error) {
     logger.error('Error processing CSP report', {
       error:
@@ -115,7 +114,7 @@ async function handleCSPReport(context: ApiContext): Promise<Response> {
           : API_ERROR_MESSAGES.FALLBACK.UNKNOWN_ERROR,
     });
     // Still return 204 to avoid blocking browser reporting
-    return new NextResponse(null, { status: STATUS_CODES.NO_CONTENT });
+    return new Response(null, { status: STATUS_CODES.NO_CONTENT });
   }
 }
 
@@ -124,15 +123,20 @@ async function handleCSPReport(context: ApiContext): Promise<Response> {
  *
  * Uses withApiHandler wrapper for standardized middleware (rate limiting, logging).
  * Preserves 204 response behavior for browser CSP reporting compatibility.
+ * SECURITY: skipCSRF is set to true because CSP reports are sent out-of-band by the browser
+ * and do not have side effects on user sessions, so CSRF verification is not required.
  */
-export const POST = withApiHandler(handleCSPReport, { rateLimit: 'lenient' });
+export const POST = withApiHandler(handleCSPReport, {
+  rateLimit: 'lenient',
+  skipCSRF: true,
+});
 
 /**
  * OPTIONS handler for CORS preflight
  * Browsers may send preflight requests before CSP reports
  */
 export async function OPTIONS(): Promise<Response> {
-  return new NextResponse(null, {
+  return new Response(null, {
     status: STATUS_CODES.NO_CONTENT,
     headers: {
       'Access-Control-Allow-Origin': SECURITY_CONFIG.CORS.ALLOW_ORIGIN,

--- a/tests/security/sentinel-enhancements.test.ts
+++ b/tests/security/sentinel-enhancements.test.ts
@@ -2,12 +2,14 @@ import { sanitizeHtml } from '@/lib/validation';
 import { withApiHandler } from '@/lib/api-handler/wrapper';
 import { detectSuspiciousPatterns } from '@/lib/security/suspicious-patterns';
 import { NextRequest } from 'next/server';
+import { POST as handleCSPReportPOST } from '@/app/api/csp-report/route';
 
 // Mock dependencies
 jest.mock('@/lib/security/audit-log', () => ({
   SecurityAuditLog: {
     logEvent: jest.fn(),
     logRateLimit: jest.fn(),
+    logCSPViolation: jest.fn(),
   },
 }));
 
@@ -109,6 +111,27 @@ describe('Sentinel Security Enhancements', () => {
       const response = await wrapped(request, { params: Promise.resolve({}) });
       expect(response.status).toBe(200);
       expect(mockHandler).toHaveBeenCalled();
+    });
+  });
+
+  describe('CSP Report Endpoint CSRF Bypass', () => {
+    it('should allow POST requests without Origin or Referer headers by skipping CSRF validation', async () => {
+      const request = new NextRequest('http://localhost/api/csp-report', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          'csp-report': {
+            'document-uri': 'http://localhost/api/test',
+            'violated-directive': 'script-src',
+            'blocked-uri': 'http://evil.com/malicious.js',
+          },
+        }),
+      });
+
+      const response = await handleCSPReportPOST(request, { params: Promise.resolve({}) });
+      expect(response.status).toBe(204);
     });
   });
 });


### PR DESCRIPTION
This change configures the POST handler in the /api/csp-report route to skip CSRF validation. CSP violation reports are natively sent out-of-band by browsers and do not carry custom anti-CSRF headers. Enforcing CSRF on this endpoint leads to rejected reports if origin/referrer headers are stripped or altered by security-conscious clients.

To ensure high availability and robust logging of browser security telemetry:
1. Enabled `skipCSRF: true` on the POST handler wrapper options in `src/app/api/csp-report/route.ts`.
2. Refactored the route to return standard global `Response` instances instead of Next.js `NextResponse` to resolve ESM constructor resolution errors in Jest/Node and improve Cloudflare Pages/Workers compatibility.
3. Added a dedicated unit test in `tests/security/sentinel-enhancements.test.ts` to ensure requests without Origin/Referer headers are successfully ingested and return 204 No Content.
4. Documented the pattern and learning in `docs/security/sentinel.md`.

---
*PR created automatically by Jules for task [1462443394584093113](https://jules.google.com/task/1462443394584093113) started by @cpa03*