### PR TITLE
🎨 Palette: Refactor Dashboard Redirects to Standard Client Router

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useCallback, useRef } from 'react';
+import { useRouter } from 'next/navigation';
 import { fetchWithTimeout } from '@/lib/api-client';
 import dynamic from 'next/dynamic';
 import { useAuthCheck } from '@/hooks/useAuthCheck';
@@ -42,6 +43,7 @@ import {
   ICON_SIZES,
   COMPONENT_CONFIG,
   KBD_HINT_STYLE,
+  createRouteWithParams,
 } from '@/lib/config';
 import type { ComponentConfig } from '@/lib/config/components';
 import {
@@ -119,6 +121,7 @@ const formatDateAbsolute = (dateString: string): string => {
 };
 
 export default function DashboardPage() {
+  const router = useRouter();
   const [ideas, setIdeas] = useState<Idea[]>([]);
   const [pagination, setPagination] = useState<Pagination | null>(null);
   const [loading, setLoading] = useState(true);
@@ -153,12 +156,12 @@ export default function DashboardPage() {
       }
       triggerHapticFeedback();
       if (idea.status === IDEA_STATUS_CONFIG.TYPES.COMPLETED) {
-        window.location.href = `/results?ideaId=${idea.id}`;
+        router.push(createRouteWithParams(ROUTES.RESULTS, { ideaId: idea.id }));
       } else {
-        window.location.href = `/clarify?ideaId=${idea.id}`;
+        router.push(createRouteWithParams(ROUTES.CLARIFY, { ideaId: idea.id }));
       }
     },
-    []
+    [router]
   );
   const { isAuthenticated, isLoading: authLoading, userId } = useAuthCheck();
   const { openHelp } = useKeyboardShortcuts();
@@ -460,9 +463,9 @@ export default function DashboardPage() {
         if (idea) {
           triggerHapticFeedback();
           if (idea.status === IDEA_STATUS_CONFIG.TYPES.COMPLETED) {
-            window.location.href = `/results?ideaId=${idea.id}`;
+            router.push(createRouteWithParams(ROUTES.RESULTS, { ideaId: idea.id }));
           } else {
-            window.location.href = `/clarify?ideaId=${idea.id}`;
+            router.push(createRouteWithParams(ROUTES.CLARIFY, { ideaId: idea.id }));
           }
         }
         return;
@@ -555,7 +558,7 @@ export default function DashboardPage() {
       ) {
         e.preventDefault();
         triggerHapticFeedback();
-        window.location.href = ROUTES.HOME;
+        router.push(ROUTES.HOME);
       }
     };
 
@@ -571,6 +574,7 @@ export default function DashboardPage() {
     filter,
     handleClearFilter,
     openHelp,
+    router,
   ]);
 
   useEffect(() => {


### PR DESCRIPTION
Refactored all relative window.location.href assignments inside the DashboardPage client component to utilize Next.js's standard client-side router (useRouter) and the modular createRouteWithParams utility. 

This enhances user experience by avoiding full-page browser refreshes (page flashes) during redirects, ensuring standard, seamless SPA transitions. Additionally, this completely resolves all @next/next/no-location-assign-relative-destination ESLint warnings in the codebase.

---
*PR created automatically by Jules for task [4095694043641441462](https://jules.google.com/task/4095694043641441462) started by @cpa03*