### PR TITLE
🛡️ Sentinel: Fix SSRF bypasses via advanced IPv6 loopback and unspecified addresses

### DIFF
--- a/docs/security/sentinel.md
+++ b/docs/security/sentinel.md
@@ -47,3 +47,9 @@ This document tracks security vulnerabilities discovered and lessons learned to 
 **Vulnerability:** The Server-Side Request Forgery (SSRF) detection patterns in `src/lib/config/security-patterns.ts` were vulnerable to bypasses using shorthand IPv4 loopback notation (e.g. `127.1`, `127.0.1`), class A loopback subnet ranges (e.g., `127.12.34.56`), and non-standard/omitted protocol prefixes (e.g., `//0x7f000001` or raw numeric/hex formats like `2130706433` or `0x7f000001`).
 **Learning:** Security rules that strictly check contiguous strings or expect specific protocol schemes (`http(s)://`) are easily bypassed by browsers and parsers that automatically normalize or resolve alternate IP formats, protocol-relative syntax, or omitted schemes.
 **Prevention:** Design input validation and security patterns defensively to match any standard loopback address in the entire `127.0.0.0/8` block and support optional, omitted, or protocol-relative schemes for non-standard IP encodings.
+
+## 2026-08-06 - SSRF Bypass via Advanced IPv6 Loopback and Unspecified Addresses
+
+**Vulnerability:** SSRF blocklist patterns in `src/lib/config/security-patterns.ts` did not detect advanced/alternate IPv6 loopback (e.g., `[0:0:0:0:0:0:0:1]`, `[0::1]`) and unspecified (e.g., `[0:0:0:0:0:0:0:0]`, `[0::0]`, `[0::]`) representations. Attackers can leverage these representations to bypass naive SSRF filters since web clients still resolve them to local targets.
+**Learning:** Regex-based SSRF mitigations often overlook the rich variety of formats supported by IPv6 (e.g., full-length, double-colon compressed, optional trailing colons, and varying zero-padding).
+**Prevention:** Always design IPv6 loopback patterns defensively with robust patterns that match brackets containing any valid IPv6 loopback and unspecified variants (both compressed and full-length, ending in 0 or 1).

--- a/src/lib/config/security-patterns.ts
+++ b/src/lib/config/security-patterns.ts
@@ -242,6 +242,13 @@ export const SUSPICIOUS_PATTERNS_CONFIG: Record<
       description: 'Localhost SSRF attempt',
     },
     {
+      // SECURITY: Added to detect advanced IPv6 loopback (e.g., [0:0:0:0:0:0:0:1], [0::1])
+      // and unspecified (e.g., [0:0:0:0:0:0:0:0], [0::0], [0::]) loopback representations.
+      pattern: /(?:\[0*(?:0{1,4}:){1,7}0*1\]|\[0*::+0*1\]|\[0*(?:0{1,4}:){1,7}0*0\]|\[0*::+0*0?\])/i,
+      severity: 2,
+      description: 'Advanced IPv6 loopback SSRF attempt',
+    },
+    {
       pattern:
         /(169\.254\.169\.254|168\.63\.129\.16|100\.100\.100\.200|192\.0\.0\.192|metadata\.google|fd00:ec2::254)/i,
       severity: 3,

--- a/tests/security/ssrf-bypass.test.ts
+++ b/tests/security/ssrf-bypass.test.ts
@@ -89,4 +89,21 @@ describe('Suspicious Pattern Detection Bypasses', () => {
       expect(result.patterns.some((p) => p.category === 'ssrf')).toBe(true);
     }
   });
+
+  it('should detect SSRF with advanced IPv6 loopback and unspecified addresses', () => {
+    const cases = [
+      'https://example.com/api/test?url=http://[0:0:0:0:0:0:0:1]',
+      'https://example.com/api/test?url=http://[0000:0000:0000:0000:0000:0000:0000:0001]',
+      'https://example.com/api/test?url=http://[0::1]',
+      'https://example.com/api/test?url=http://[0:0:0:0:0:0:0:0]',
+      'https://example.com/api/test?url=http://[0::0]',
+      'https://example.com/api/test?url=http://[0::]',
+    ];
+    for (const url of cases) {
+      const request = createMockRequest(url);
+      const result = detectSuspiciousPatterns(request, { minSeverity: 1 });
+      expect(result.detected).toBe(true);
+      expect(result.patterns.some((p) => p.category === 'ssrf')).toBe(true);
+    }
+  });
 });


### PR DESCRIPTION
Secured the application's SSRF protection against advanced loopback and unspecified IPv6 address representations.

Summary of Changes:
1. Updated `src/lib/config/security-patterns.ts` to include a robust pattern targeting advanced/alternate IPv6 loopback and unspecified representations (e.g., `[0:0:0:0:0:0:0:1]`, `[0::1]`, `[0::]`).
2. Added comprehensive unit tests in `tests/security/ssrf-bypass.test.ts` to cover all of these edge cases.
3. Documented findings and preventative measures in the Sentinel security journal (`docs/security/sentinel.md`).

---
*PR created automatically by Jules for task [909067143245484999](https://jules.google.com/task/909067143245484999) started by @cpa03*