### PR TITLE
🎨 Palette: Add keyboard focus outline to onboarding step dots

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import './.next/types/routes.d.ts';
+import "./.next/dev/types/routes.d.ts";
+import "./.next/dev/types/root-params.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,7 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
-import "./.next/dev/types/root-params.d.ts";
+import './.next/types/routes.d.ts';
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/components/UserOnboarding.tsx
+++ b/src/components/UserOnboarding.tsx
@@ -499,7 +499,7 @@ export default function UserOnboarding() {
                       setCurrentStepIndex(index);
                     }
                   }}
-                  className={`rounded-full transition-all ${DURATION_TAILWIND[200]} ease-out ${
+                  className={`rounded-full transition-all ${DURATION_TAILWIND[200]} ease-out ${FOCUS_RING_PATTERNS.DEFAULT} ${
                     index === currentStepIndex
                       ? `${INDICATOR_SIZES.PILL} ${BG_COLORS.BRAND}`
                       : index < currentStepIndex


### PR DESCRIPTION
This pull request adds focus-visible ring styles using existing design tokens (FOCUS_RING_PATTERNS.DEFAULT) to the interactive progress step dot buttons in UserOnboarding.tsx. This ensures proper keyboard accessibility (WCAG 2.1 compliance) for users navigating through the tour using only their keyboard.

---
*PR created automatically by Jules for task [12356495622633248920](https://jules.google.com/task/12356495622633248920) started by @cpa03*