### PR TITLE
🛡️ Sentinel: Harden environment validation for integration client secrets and tokens

### DIFF
--- a/docs/security/sentinel.md
+++ b/docs/security/sentinel.md
@@ -53,3 +53,9 @@ This document tracks security vulnerabilities discovered and lessons learned to 
 **Vulnerability:** SSRF blocklist patterns in `src/lib/config/security-patterns.ts` did not detect advanced/alternate IPv6 loopback (e.g., `[0:0:0:0:0:0:0:1]`, `[0::1]`) and unspecified (e.g., `[0:0:0:0:0:0:0:0]`, `[0::0]`, `[0::]`) representations. Attackers can leverage these representations to bypass naive SSRF filters since web clients still resolve them to local targets.
 **Learning:** Regex-based SSRF mitigations often overlook the rich variety of formats supported by IPv6 (e.g., full-length, double-colon compressed, optional trailing colons, and varying zero-padding).
 **Prevention:** Always design IPv6 loopback patterns defensively with robust patterns that match brackets containing any valid IPv6 loopback and unspecified variants (both compressed and full-length, ending in 0 or 1).
+
+## 2026-08-08 - Loose Integration Secrets Validation Gaps
+
+**Vulnerability:** High-risk third-party client secrets (`GITHUB_CLIENT_SECRET`, `NOTION_CLIENT_SECRET`), OAuth refresh tokens (`GOOGLE_REFRESH_TOKEN`), and private analytics keys (`POSTHOG_API_KEY`) were not covered by strict server startup validation. This could lead to accidental frontend exposure through `NEXT_PUBLIC_` prefixes, use of default/example values, or weak/short keys in production.
+**Learning:** When adding standard environment variable keys or examples to configuration, developers often neglect registering them in strict runtime security validators. This results in inconsistent protection where some integrations are hardened while others remain vulnerable to leakage or weak configurations.
+**Prevention:** Centralize all sensitive integration credentials in type-safe environment key accessors and map them directly into a strict validation whitelist. Ensure any private OAuth or client secret is explicitly protected against frontend bundling and validated for high-entropy strength in production.

--- a/src/lib/config/env-keys.ts
+++ b/src/lib/config/env-keys.ts
@@ -48,12 +48,16 @@ export const EXPORT_ENV_KEYS = {
   GITHUB_TOKEN: 'GITHUB_TOKEN',
   /** GitHub OAuth client ID */
   GITHUB_CLIENT_ID: 'GITHUB_CLIENT_ID',
+  /** GitHub OAuth client secret */
+  GITHUB_CLIENT_SECRET: 'GITHUB_CLIENT_SECRET',
   /** GitHub OAuth redirect URI */
   GITHUB_REDIRECT_URI: 'GITHUB_REDIRECT_URI',
   /** Notion API key */
   NOTION_API_KEY: 'NOTION_API_KEY',
   /** Notion OAuth client ID */
   NOTION_CLIENT_ID: 'NOTION_CLIENT_ID',
+  /** Notion OAuth client secret */
+  NOTION_CLIENT_SECRET: 'NOTION_CLIENT_SECRET',
   /** Notion OAuth redirect URI */
   NOTION_REDIRECT_URI: 'NOTION_REDIRECT_URI',
   /** Notion parent page ID for creating pages */
@@ -70,6 +74,8 @@ export const EXPORT_ENV_KEYS = {
   GOOGLE_CLIENT_SECRET: 'GOOGLE_CLIENT_SECRET',
   /** Google OAuth redirect URI */
   GOOGLE_REDIRECT_URI: 'GOOGLE_REDIRECT_URI',
+  /** Google OAuth refresh token */
+  GOOGLE_REFRESH_TOKEN: 'GOOGLE_REFRESH_TOKEN',
 } as const;
 
 /**
@@ -185,11 +191,15 @@ export const ENV_ACCESSORS = {
     GITHUB_TOKEN: () => EnvLoader.string(EXPORT_ENV_KEYS.GITHUB_TOKEN, ''),
     GITHUB_CLIENT_ID: () =>
       EnvLoader.string(EXPORT_ENV_KEYS.GITHUB_CLIENT_ID, ''),
+    GITHUB_CLIENT_SECRET: () =>
+      EnvLoader.string(EXPORT_ENV_KEYS.GITHUB_CLIENT_SECRET, ''),
     GITHUB_REDIRECT_URI: () =>
       EnvLoader.string(EXPORT_ENV_KEYS.GITHUB_REDIRECT_URI, ''),
     NOTION_API_KEY: () => EnvLoader.string(EXPORT_ENV_KEYS.NOTION_API_KEY, ''),
     NOTION_CLIENT_ID: () =>
       EnvLoader.string(EXPORT_ENV_KEYS.NOTION_CLIENT_ID, ''),
+    NOTION_CLIENT_SECRET: () =>
+      EnvLoader.string(EXPORT_ENV_KEYS.NOTION_CLIENT_SECRET, ''),
     NOTION_REDIRECT_URI: () =>
       EnvLoader.string(EXPORT_ENV_KEYS.NOTION_REDIRECT_URI, ''),
     NOTION_PARENT_PAGE_ID: () =>
@@ -204,6 +214,8 @@ export const ENV_ACCESSORS = {
       EnvLoader.string(EXPORT_ENV_KEYS.GOOGLE_CLIENT_SECRET, ''),
     GOOGLE_REDIRECT_URI: () =>
       EnvLoader.string(EXPORT_ENV_KEYS.GOOGLE_REDIRECT_URI, ''),
+    GOOGLE_REFRESH_TOKEN: () =>
+      EnvLoader.string(EXPORT_ENV_KEYS.GOOGLE_REFRESH_TOKEN, ''),
   },
 
   /** Platform detection keys */

--- a/src/lib/security/env-validation.ts
+++ b/src/lib/security/env-validation.ts
@@ -25,10 +25,14 @@ const SENSITIVE_KEYS = [
   'ANTHROPIC_API_KEY',
   'INTERNAL_API_SECRET',
   'NOTION_API_KEY',
+  'NOTION_CLIENT_SECRET',
   'TRELLO_API_KEY',
   'TRELLO_TOKEN',
   'GITHUB_TOKEN',
+  'GITHUB_CLIENT_SECRET',
   'GOOGLE_CLIENT_SECRET',
+  'GOOGLE_REFRESH_TOKEN',
+  'POSTHOG_API_KEY',
 ] as const;
 
 /**
@@ -130,10 +134,14 @@ const MUST_BE_PRIVATE = [
   'ANTHROPIC_API_KEY',
   'INTERNAL_API_SECRET',
   'NOTION_API_KEY',
+  'NOTION_CLIENT_SECRET',
   'TRELLO_API_KEY',
   'TRELLO_TOKEN',
   'GITHUB_TOKEN',
+  'GITHUB_CLIENT_SECRET',
   'GOOGLE_CLIENT_SECRET',
+  'GOOGLE_REFRESH_TOKEN',
+  'POSTHOG_API_KEY',
 ] as const;
 
 /**
@@ -457,6 +465,32 @@ export function validateEnvironment(): ValidationResult {
     warnings.push(
       ...checkSecretStrength('GOOGLE_CLIENT_SECRET', googleClientSecret)
     );
+  }
+
+  const notionClientSecret = ENV_ACCESSORS.EXPORT.NOTION_CLIENT_SECRET();
+  if (notionClientSecret) {
+    warnings.push(
+      ...checkSecretStrength('NOTION_CLIENT_SECRET', notionClientSecret)
+    );
+  }
+
+  const githubClientSecret = ENV_ACCESSORS.EXPORT.GITHUB_CLIENT_SECRET();
+  if (githubClientSecret) {
+    warnings.push(
+      ...checkSecretStrength('GITHUB_CLIENT_SECRET', githubClientSecret)
+    );
+  }
+
+  const googleRefreshToken = ENV_ACCESSORS.EXPORT.GOOGLE_REFRESH_TOKEN();
+  if (googleRefreshToken) {
+    warnings.push(
+      ...checkSecretStrength('GOOGLE_REFRESH_TOKEN', googleRefreshToken)
+    );
+  }
+
+  const posthogApiKey = process.env.POSTHOG_API_KEY;
+  if (posthogApiKey) {
+    warnings.push(...checkSecretStrength('POSTHOG_API_KEY', posthogApiKey));
   }
 
   // AI key format validation

--- a/tests/security/env-validation.test.ts
+++ b/tests/security/env-validation.test.ts
@@ -128,6 +128,31 @@ describe('Environment Validation', () => {
       ).toBe(true);
     });
 
+    it('should detect NEXT_PUBLIC_ prefix on the newly added sensitive integration keys', () => {
+      process.env.NEXT_PUBLIC_NOTION_CLIENT_SECRET = 'notion-exposed-secret';
+      process.env.NEXT_PUBLIC_GITHUB_CLIENT_SECRET = 'github-exposed-secret';
+      process.env.NEXT_PUBLIC_GOOGLE_REFRESH_TOKEN = 'google-exposed-token';
+      process.env.NEXT_PUBLIC_POSTHOG_API_KEY = 'posthog-exposed-key';
+      process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://test.supabase.co';
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'test-anon-key';
+
+      const result = validateEnvironment();
+
+      expect(result.valid).toBe(false);
+      expect(
+        result.errors.some((e) => e.includes('NEXT_PUBLIC_NOTION_CLIENT_SECRET'))
+      ).toBe(true);
+      expect(
+        result.errors.some((e) => e.includes('NEXT_PUBLIC_GITHUB_CLIENT_SECRET'))
+      ).toBe(true);
+      expect(
+        result.errors.some((e) => e.includes('NEXT_PUBLIC_GOOGLE_REFRESH_TOKEN'))
+      ).toBe(true);
+      expect(
+        result.errors.some((e) => e.includes('NEXT_PUBLIC_POSTHOG_API_KEY'))
+      ).toBe(true);
+    });
+
     it('should warn about placeholders and weak strength on integration keys outside development', () => {
       // Set to production to enable strength/complexity checks
       Object.defineProperty(process.env, 'NODE_ENV', {
@@ -159,6 +184,63 @@ describe('Environment Validation', () => {
       expect(
         result.warnings.some(
           (w) => w.includes('TRELLO_API_KEY') && w.includes('too short')
+        )
+      ).toBe(true);
+    });
+
+    it('should warn about placeholders and weak strength on the newly added sensitive integration keys outside development', () => {
+      // Set to production to enable strength/complexity checks
+      Object.defineProperty(process.env, 'NODE_ENV', {
+        value: 'production',
+        writable: true,
+      });
+      process.env.NOTION_CLIENT_SECRET = 'your_notion_secret_here'; // placeholder
+      process.env.GITHUB_CLIENT_SECRET = 'your_github_secret_here'; // placeholder
+      process.env.GOOGLE_REFRESH_TOKEN = 'your_google_token_here'; // placeholder
+      process.env.POSTHOG_API_KEY = 'your_posthog_key_here'; // placeholder
+      process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://test.supabase.co';
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'test-anon-key';
+
+      const result = validateEnvironment();
+
+      expect(
+        result.warnings.some(
+          (w) => w.includes('NOTION_CLIENT_SECRET') && w.includes('placeholder')
+        )
+      ).toBe(true);
+      expect(
+        result.warnings.some(
+          (w) => w.includes('NOTION_CLIENT_SECRET') && w.includes('too short')
+        )
+      ).toBe(true);
+      expect(
+        result.warnings.some(
+          (w) => w.includes('GITHUB_CLIENT_SECRET') && w.includes('placeholder')
+        )
+      ).toBe(true);
+      expect(
+        result.warnings.some(
+          (w) => w.includes('GITHUB_CLIENT_SECRET') && w.includes('too short')
+        )
+      ).toBe(true);
+      expect(
+        result.warnings.some(
+          (w) => w.includes('GOOGLE_REFRESH_TOKEN') && w.includes('placeholder')
+        )
+      ).toBe(true);
+      expect(
+        result.warnings.some(
+          (w) => w.includes('GOOGLE_REFRESH_TOKEN') && w.includes('too short')
+        )
+      ).toBe(true);
+      expect(
+        result.warnings.some(
+          (w) => w.includes('POSTHOG_API_KEY') && w.includes('placeholder')
+        )
+      ).toBe(true);
+      expect(
+        result.warnings.some(
+          (w) => w.includes('POSTHOG_API_KEY') && w.includes('too short')
         )
       ).toBe(true);
     });


### PR DESCRIPTION
Expanded strict server-side environment validation to cover GITHUB_CLIENT_SECRET, NOTION_CLIENT_SECRET, GOOGLE_REFRESH_TOKEN, and POSTHOG_API_KEY. This validates them against accidental frontend prefixing (NEXT_PUBLIC_), placeholder/example values, and weak strength/complexity configs in production. Added type-safe accessors in env-keys.ts and comprehensive unit tests.

---
*PR created automatically by Jules for task [11769130672378869469](https://jules.google.com/task/11769130672378869469) started by @cpa03*