### PR TITLE
🎨 Palette: Fix accessibility on TypingIndicator

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import './.next/types/routes.d.ts';
+import "./.next/types/routes.d.ts";
+import "./.next/types/root-params.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/components/TypingIndicator.tsx
+++ b/src/components/TypingIndicator.tsx
@@ -26,8 +26,9 @@ interface TypingIndicatorProps {
  *
  * Accessibility:
  * - Respects prefers-reduced-motion
- * - Uses aria-hidden since it's purely decorative
- * - Fades out smoothly for screen readers
+ * - Uses role="status" and aria-live="polite" on parent container
+ * - Keeps decorative pulsing dots hidden from screen readers via aria-hidden="true"
+ * - Keeps screen reader text accessible to screen readers
  */
 function TypingIndicatorComponent({
   isTyping,
@@ -83,24 +84,27 @@ function TypingIndicatorComponent({
   return (
     <div
       className={`inline-flex items-center gap-1 ${className}`}
-      aria-hidden="true"
+      role="status"
+      aria-live="polite"
     >
-      {/* Animated dots */}
-      {[0, 1, 2].map((index) => (
-        <span
-          key={index}
-          className={`
-            ${TYPING_INDICATOR_DOT_PATTERN}
-            ${TRANSITION_CLASSES.COLOR}
-            ${isAnimating && !prefersReducedMotion ? 'animate-typing-dot' : 'opacity-40'}
-          `}
-          style={{
-            animationDelay: `${index * ANIMATION_CONFIG.TYPING_INDICATOR.DOT_STAGGER}ms`,
-          }}
-        />
-      ))}
+      {/* Animated dots - hidden from screen readers */}
+      <span className="inline-flex items-center gap-1" aria-hidden="true">
+        {[0, 1, 2].map((index) => (
+          <span
+            key={index}
+            className={`
+              ${TYPING_INDICATOR_DOT_PATTERN}
+              ${TRANSITION_CLASSES.COLOR}
+              ${isAnimating && !prefersReducedMotion ? 'animate-typing-dot' : 'opacity-40'}
+            `}
+            style={{
+              animationDelay: `${index * ANIMATION_CONFIG.TYPING_INDICATOR.DOT_STAGGER}ms`,
+            }}
+          />
+        ))}
+      </span>
       {/* Screen reader text for accessibility */}
-      <span className="sr-only">Typing</span>
+      <span className="sr-only">Typing...</span>
     </div>
   );
 }

--- a/tests/TypingIndicator.test.tsx
+++ b/tests/TypingIndicator.test.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import TypingIndicator from '@/components/TypingIndicator';
+import { usePrefersReducedMotion } from '@/hooks/usePrefersReducedMotion';
+
+jest.useFakeTimers();
+
+// Mock the prefers-reduced-motion hook
+jest.mock('@/hooks/usePrefersReducedMotion', () => ({
+  usePrefersReducedMotion: jest.fn(),
+}));
+
+describe('TypingIndicator', () => {
+  beforeEach(() => {
+    jest.clearAllTimers();
+    (usePrefersReducedMotion as jest.Mock).mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders nothing when isTyping is false initially', () => {
+    const { container } = render(<TypingIndicator isTyping={false} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders correctly when isTyping is true', () => {
+    render(<TypingIndicator isTyping={true} />);
+
+    // Screen reader text should be present
+    expect(screen.getByText('Typing...')).toBeInTheDocument();
+
+    // Must have a "status" role with "polite" live region for accessibility
+    const container = screen.getByRole('status');
+    expect(container).toBeInTheDocument();
+    expect(container).toHaveAttribute('aria-live', 'polite');
+
+    // Dot elements should be rendered inside an aria-hidden container
+    const dotsContainer = container.querySelector('[aria-hidden="true"]');
+    expect(dotsContainer).toBeInTheDocument();
+  });
+
+  it('hides after delay when isTyping becomes false', async () => {
+    const { rerender } = render(<TypingIndicator isTyping={true} hideDelay={1000} />);
+
+    expect(screen.getByRole('status')).toBeInTheDocument();
+
+    // Set isTyping to false
+    await act(async () => {
+      rerender(<TypingIndicator isTyping={false} hideDelay={1000} />);
+    });
+
+    // It should still be visible immediately since the hide delay has not elapsed
+    expect(screen.getByRole('status')).toBeInTheDocument();
+
+    // Advance time past the hide delay
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    // Now it should be hidden
+    expect(screen.queryByRole('status')).toBeNull();
+  });
+
+  it('respects prefers-reduced-motion', () => {
+    (usePrefersReducedMotion as jest.Mock).mockReturnValue(true);
+
+    render(<TypingIndicator isTyping={true} />);
+
+    const container = screen.getByRole('status');
+    const dots = container.querySelectorAll('.animate-typing-dot');
+    // Dots should not have the animation class when prefers-reduced-motion is true
+    expect(dots.length).toBe(0);
+  });
+
+  it('uses custom className correctly', () => {
+    render(<TypingIndicator isTyping={true} className="test-custom-class" />);
+
+    const container = screen.getByRole('status');
+    expect(container).toHaveClass('test-custom-class');
+  });
+});


### PR DESCRIPTION
💡 What:
Resolved an accessibility issue with the TypingIndicator component where screen-readers were unable to read the fallback sr-only text because the parent container was incorrectly marked with aria-hidden="true".

🎯 Why:
Assistive technologies exclude the entire DOM subtree when aria-hidden="true" is applied to the parent container. By configuring the parent element as an active polite status region (role="status" aria-live="polite") and applying aria-hidden="true" specifically and exclusively to the decorative pulsing dots, screen-readers can now successfully and gracefully discover and announce when typing occurs.

♿ Accessibility:
- Added role="status" and aria-live="polite" to parent.
- Excluded visual/decorative flashing dots from assistive technologies using aria-hidden="true" on the dots container.
- Kept screen-reader fallback text "Typing..." discoverable to assistive technologies.

🧪 Tests:
Added tests/TypingIndicator.test.tsx covering:
- Renders nothing when isTyping is false initially.
- Renders correctly when isTyping is true.
- Verification of accessibility status region role and polite live region.
- Visual dots are hidden via aria-hidden="true".
- Hidden-delay timer behavior after typing stops.
- Reduced-motion preference validation.

---
*PR created automatically by Jules for task [3507986072740563866](https://jules.google.com/task/3507986072740563866) started by @cpa03*