### PR TITLE
🎨 Palette: referral link accessibility improvement

### DIFF
--- a/src/components/ReferralLink.tsx
+++ b/src/components/ReferralLink.tsx
@@ -177,6 +177,7 @@ function ReferralLinkComponent({
                 onKeyDown={handleCodeKeyDown}
                 onBlur={handleBlur}
                 tabIndex={0}
+                role="button"
                 aria-label={`${referralUrl}. Press Space or Enter to select the link.`}
                 className={`w-full min-w-0 px-3 py-2 ${WHITE_BG_PATTERNS.DEFAULT} border border-primary-200 rounded-md text-sm text-primary-800 truncate font-mono cursor-pointer ${GRAY_CLASSES.HOVER_BG_50} transition-all ${DURATION_TAILWIND[200]} outline-none ${FOCUS_RING_PATTERNS.DEFAULT}`}
               >

--- a/tests/ReferralLink.test.tsx
+++ b/tests/ReferralLink.test.tsx
@@ -37,6 +37,7 @@ describe('ReferralLink', () => {
       'aria-label',
       'http://localhost/signup?ref=testcode123. Press Space or Enter to select the link.'
     );
+    expect(codeElement).toHaveAttribute('role', 'button');
     expect(codeElement.className).toContain('focus-visible:ring-2');
     expect(codeElement.className).toContain('focus-visible:ring-primary-500');
   });


### PR DESCRIPTION
This PR improves accessibility of the interactive copyable referral link in the `ReferralLink` component by adding `role="button"` to the `<code>` element. This guarantees screen readers correctly identify it as an interactive button control. Includes corresponding test updates in `tests/ReferralLink.test.tsx` and a recorded journal entry in `.jules/palette.md`.

---
*PR created automatically by Jules for task [4789742175654969066](https://jules.google.com/task/4789742175654969066) started by @cpa03*